### PR TITLE
Add unit tests for document tracker and auto closer with caret sentinel hook

### DIFF
--- a/src/main/java/ch/so/agi/lsp/interlis/DocumentTracker.java
+++ b/src/main/java/ch/so/agi/lsp/interlis/DocumentTracker.java
@@ -1,0 +1,194 @@
+package ch.so.agi.lsp.interlis;
+
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.Range;
+import org.eclipse.lsp4j.TextDocumentContentChangeEvent;
+import org.eclipse.lsp4j.VersionedTextDocumentIdentifier;
+import org.eclipse.lsp4j.TextDocumentItem;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Keeps track of the live contents of open text documents so on-type features can
+ * operate on the latest edits (even when the file is unsaved).
+ */
+final class DocumentTracker {
+
+    private static final class DocumentState {
+        String text;
+        Integer version;
+
+        DocumentState(String text, Integer version) {
+            this.text = text != null ? text : "";
+            this.version = version;
+        }
+    }
+
+    private final Map<String, DocumentState> documents = new ConcurrentHashMap<>();
+
+    void open(TextDocumentItem item) {
+        if (item == null) return;
+        documents.put(item.getUri(), new DocumentState(item.getText(), item.getVersion()));
+    }
+
+    void close(String uri) {
+        if (uri != null) {
+            documents.remove(uri);
+        }
+    }
+
+    void applyChanges(VersionedTextDocumentIdentifier identifier, List<TextDocumentContentChangeEvent> changes) {
+        if (identifier == null || identifier.getUri() == null || changes == null || changes.isEmpty()) {
+            return;
+        }
+
+        String uri = identifier.getUri();
+        DocumentState state = documents.computeIfAbsent(uri, u -> new DocumentState("", null));
+        String text = state.text;
+
+        for (TextDocumentContentChangeEvent change : changes) {
+            if (change.getRange() == null) {
+                // full document sync
+                text = change.getText();
+                continue;
+            }
+
+            Range range = change.getRange();
+            int start = toOffset(text, range.getStart());
+            int end = toOffset(text, range.getEnd());
+            start = clamp(start, 0, text.length());
+            end = clamp(end, start, text.length());
+
+            StringBuilder sb = new StringBuilder(text.length() + change.getText().length());
+            sb.append(text, 0, start);
+            sb.append(change.getText());
+            sb.append(text, end, text.length());
+            text = sb.toString();
+        }
+
+        state.text = text;
+        state.version = identifier.getVersion();
+    }
+
+    String getText(String uri) {
+        DocumentState state = uri == null ? null : documents.get(uri);
+        return state != null ? state.text : null;
+    }
+
+    Integer getVersion(String uri) {
+        DocumentState state = uri == null ? null : documents.get(uri);
+        return state != null ? state.version : null;
+    }
+
+    static int toOffset(String text, Position position) {
+        if (text == null || text.isEmpty() || position == null) {
+            return 0;
+        }
+
+        int line = Math.max(position.getLine(), 0);
+        int character = Math.max(position.getCharacter(), 0);
+        int index = 0;
+        int currentLine = 0;
+        int length = text.length();
+
+        while (index < length && currentLine < line) {
+            char ch = text.charAt(index++);
+            if (ch == '\r') {
+                if (index < length && text.charAt(index) == '\n') {
+                    index++;
+                }
+                currentLine++;
+            } else if (ch == '\n') {
+                currentLine++;
+            }
+        }
+
+        // Clamp to end of document if requested line is beyond current length
+        if (currentLine < line) {
+            return length;
+        }
+
+        int lineStart = index;
+        int remaining = character;
+        while (index < length && remaining > 0) {
+            char ch = text.charAt(index);
+            if (ch == '\n' || ch == '\r') {
+                break;
+            }
+            index++;
+            remaining--;
+        }
+
+        return index;
+    }
+
+    static Position positionAt(String text, int offset) {
+        if (text == null || text.isEmpty()) {
+            return new Position(0, 0);
+        }
+
+        int length = text.length();
+        int safeOffset = clamp(offset, 0, length);
+        int line = 0;
+        int column = 0;
+
+        for (int i = 0; i < safeOffset; i++) {
+            char ch = text.charAt(i);
+            if (ch == '\r') {
+                if (i + 1 < safeOffset && text.charAt(i + 1) == '\n') {
+                    i++;
+                }
+                line++;
+                column = 0;
+            } else if (ch == '\n') {
+                line++;
+                column = 0;
+            } else {
+                column++;
+            }
+        }
+
+        return new Position(line, column);
+    }
+
+    static int lineStartOffset(String text, int lineNumber) {
+        if (text == null || text.isEmpty()) {
+            return 0;
+        }
+        if (lineNumber <= 0) {
+            return 0;
+        }
+
+        int length = text.length();
+        int line = 0;
+
+        for (int i = 0; i < length; i++) {
+            char ch = text.charAt(i);
+            if (line == lineNumber) {
+                return i;
+            }
+            if (ch == '\r') {
+                if (i + 1 < length && text.charAt(i + 1) == '\n') {
+                    i++;
+                }
+                line++;
+                if (line == lineNumber) {
+                    return Math.min(i + 1, length);
+                }
+            } else if (ch == '\n') {
+                line++;
+                if (line == lineNumber) {
+                    return Math.min(i + 1, length);
+                }
+            }
+        }
+        return length;
+    }
+
+    private static int clamp(int value, int min, int max) {
+        return Math.max(min, Math.min(max, value));
+    }
+}
+

--- a/src/main/java/ch/so/agi/lsp/interlis/InterlisAutoCloser.java
+++ b/src/main/java/ch/so/agi/lsp/interlis/InterlisAutoCloser.java
@@ -1,0 +1,385 @@
+package ch.so.agi.lsp.interlis;
+
+import org.eclipse.lsp4j.DocumentOnTypeFormattingParams;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.Range;
+import org.eclipse.lsp4j.TextEdit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Auto-inserts boilerplate when '=' is typed after selected INTERLIS headers.
+ * Ported from the jEdit plugin implementation, but adapted to return LSP TextEdits.
+ */
+final class InterlisAutoCloser {
+    private static final Logger LOG = LoggerFactory.getLogger(InterlisAutoCloser.class);
+
+    private static final int LOOKBACK_CHARS = 1200;
+    private static final DateTimeFormatter ISO_DAY = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+    private static final ZoneId ZURICH = ZoneId.of("Europe/Zurich");
+    static final String CARET_SENTINEL = "__INTERLIS_AUTOCLOSE_CARET__";
+
+    private InterlisAutoCloser() {}
+
+    static List<TextEdit> computeEdits(String text,
+                                       DocumentOnTypeFormattingParams params) {
+        if (text == null || params == null || params.getCh() == null) {
+            return Collections.emptyList();
+        }
+
+        if (!"=".equals(params.getCh())) {
+            return Collections.emptyList();
+        }
+
+        int offset = DocumentTracker.toOffset(text, params.getPosition());
+        if (offset <= 0 || offset > text.length()) {
+            return Collections.emptyList();
+        }
+
+        int eqOffset = offset - 1;
+        if (eqOffset < 0 || text.charAt(eqOffset) != '=') {
+            // If we cannot see the inserted '=' yet, skip instead of risking corruption
+            return Collections.emptyList();
+        }
+
+        int tailStart = Math.max(0, eqOffset - LOOKBACK_CHARS);
+        String tail = text.substring(tailStart, eqOffset);
+
+        List<Token> tokens = Lexer.lex(tail);
+        ParseResult res = Parser.parseHeaderEndingAtTail(tokens);
+        if (res == null) {
+            return Collections.emptyList();
+        }
+
+        String indent = leadingIndent(text, tailStart + res.keywordPosInTail);
+
+        switch (res.kind) {
+            case MODEL:
+                return modelTemplate(text, params, tailStart, res, indent, eqOffset);
+            case VIEW_TOPIC:
+                return Collections.singletonList(insertAfter(params.getPosition(),
+                        "\n" + indent + "DEPENDS ON " + CARET_SENTINEL
+                                + "\n" + indent
+                                + "\n" + indent + "END " + res.name + ";"));
+            case CLASS:
+            case STRUCTURE:
+            case TOPIC:
+                return Collections.singletonList(insertAfter(params.getPosition(),
+                        "\n" + indent + CARET_SENTINEL
+                                + "\n" + indent + "END " + res.name + ";"));
+            default:
+                return Collections.emptyList();
+        }
+    }
+
+    private static List<TextEdit> modelTemplate(String text,
+                                                DocumentOnTypeFormattingParams params,
+                                                int tailStart,
+                                                ParseResult res,
+                                                String indent,
+                                                int eqOffset) {
+        try {
+            String today = LocalDate.now(ZURICH).format(ISO_DAY);
+
+            String banner =
+                    "/** !!------------------------------------------------------------------------------\n" +
+                            " * !! Version    | wer | Änderung\n" +
+                            " * !!------------------------------------------------------------------------------\n" +
+                            " * !! " + today + " | abr  | Initalversion\n" +
+                            " * !!==============================================================================\n" +
+                            " */\n" +
+                            "!!@ technicalContact=mailto:acme@example.com\n" +
+                            "!!@ furtherInformation=https://example.com/path/to/information\n" +
+                            "!!@ title=\"a title\"\n" +
+                            "!!@ shortDescription=\"a short description\"\n" +
+                            "!!@ tags=\"foo,bar,fubar\"\n";
+
+            int headerLine = Math.max(params.getPosition().getLine(), 0);
+            int headerLineStart = DocumentTracker.lineStartOffset(text, headerLine);
+            Position headerPos = DocumentTracker.positionAt(text, headerLineStart);
+
+            List<TextEdit> edits = new ArrayList<>();
+            edits.add(new TextEdit(new Range(headerPos, headerPos), banner));
+
+            int nameAbsStart = tailStart + res.namePosInTail;
+            int nameAbsEnd = nameAbsStart + res.nameLen;
+            int removeStart = Math.max(nameAbsEnd, 0);
+            int removeEnd = Math.min(Math.max(eqOffset + 1, removeStart), text.length());
+
+            String mid = " (de)\n"
+                    + indent + "  AT \"https://example.com\"\n"
+                    + indent + "  VERSION \"" + today + "\"\n"
+                    + indent + "  =\n"
+                    + indent + CARET_SENTINEL + "\n"
+                    + indent + "END " + res.name + ".";
+
+            Position removeStartPos = DocumentTracker.positionAt(text, removeStart);
+            Position removeEndPos = DocumentTracker.positionAt(text, removeEnd);
+            edits.add(new TextEdit(new Range(removeStartPos, removeEndPos), mid));
+
+            return edits;
+        } catch (Exception ex) {
+            LOG.warn("Failed to build MODEL template edits for {}", res.name, ex);
+            return Collections.emptyList();
+        }
+    }
+
+    private static TextEdit insertAfter(Position position, String text) {
+        return new TextEdit(new Range(position, position), text);
+    }
+
+    private static String leadingIndent(String text, int absPos) {
+        int lineStart = 0;
+        int cursor = Math.max(absPos, 0);
+
+        for (int i = Math.min(cursor, text.length()) - 1; i >= 0; i--) {
+            char ch = text.charAt(i);
+            if (ch == '\n') {
+                lineStart = i + 1;
+                break;
+            }
+            if (ch == '\r') {
+                lineStart = i + 1;
+                if (i + 1 < text.length() && text.charAt(i + 1) == '\n') {
+                    lineStart++;
+                }
+                break;
+            }
+        }
+
+        int i = lineStart;
+        int len = text.length();
+        while (i < len) {
+            char ch = text.charAt(i);
+            if (ch == ' ' || ch == '\t') {
+                i++;
+            } else {
+                break;
+            }
+        }
+        return text.substring(lineStart, i);
+    }
+
+    private enum Kind { CLASS, STRUCTURE, TOPIC, VIEW_TOPIC, MODEL }
+
+    private enum T { CLASS, STRUCTURE, TOPIC, VIEW, MODEL, EXTENDS, LPAREN, RPAREN, COMMA, DOT, IDENT }
+
+    private static final class Token {
+        final T t;
+        final String text;
+        final int pos;
+
+        Token(T t, String text, int pos) { this.t = t; this.text = text; this.pos = pos; }
+        Token(T t, int pos) { this(t, null, pos); }
+    }
+
+    private static final class ParseResult {
+        final Kind kind;
+        final String name;
+        final int keywordPosInTail;
+        final int namePosInTail;
+        final int nameLen;
+
+        ParseResult(Kind kind, String name, int keywordPosInTail, int namePosInTail, int nameLen) {
+            this.kind = kind;
+            this.name = name;
+            this.keywordPosInTail = keywordPosInTail;
+            this.namePosInTail = namePosInTail;
+            this.nameLen = nameLen;
+        }
+    }
+
+    private static final class Lexer {
+        static List<Token> lex(String s) {
+            ArrayList<Token> out = new ArrayList<>();
+            if (s == null || s.isEmpty()) {
+                return out;
+            }
+            int i = 0;
+            int n = s.length();
+            while (i < n) {
+                char c = s.charAt(i);
+
+                if (Character.isWhitespace(c)) { i++; continue; }
+
+                if (c == '/' && i + 1 < n && s.charAt(i + 1) == '/') {
+                    i += 2;
+                    while (i < n && s.charAt(i) != '\n') i++;
+                    continue;
+                }
+                if (c == '/' && i + 1 < n && s.charAt(i + 1) == '*') {
+                    i += 2;
+                    while (i + 1 < n && !(s.charAt(i) == '*' && s.charAt(i + 1) == '/')) i++;
+                    if (i + 1 < n) i += 2;
+                    continue;
+                }
+
+                if (c == '(') { out.add(new Token(T.LPAREN, i)); i++; continue; }
+                if (c == ')') { out.add(new Token(T.RPAREN, i)); i++; continue; }
+                if (c == ',') { out.add(new Token(T.COMMA, i)); i++; continue; }
+                if (c == '.') { out.add(new Token(T.DOT, i)); i++; continue; }
+
+                if (Character.isLetter(c) || c == '_') {
+                    int j = i + 1;
+                    while (j < n) {
+                        char d = s.charAt(j);
+                        if (Character.isLetterOrDigit(d) || d == '_') j++; else break;
+                    }
+                    String w = s.substring(i, j);
+                    if      ("CLASS".equals(w))     out.add(new Token(T.CLASS, i));
+                    else if ("STRUCTURE".equals(w)) out.add(new Token(T.STRUCTURE, i));
+                    else if ("TOPIC".equals(w))     out.add(new Token(T.TOPIC, i));
+                    else if ("VIEW".equals(w))      out.add(new Token(T.VIEW, i));
+                    else if ("MODEL".equals(w))     out.add(new Token(T.MODEL, i));
+                    else if ("EXTENDS".equals(w))   out.add(new Token(T.EXTENDS, i));
+                    else                             out.add(new Token(T.IDENT, w, i));
+                    i = j;
+                    continue;
+                }
+
+                i++;
+            }
+            return out;
+        }
+    }
+
+    private static final class Parser {
+        private static final Set<String> FLAGS_CLASS = set("ABSTRACT", "EXTENDED", "FINAL");
+        private static final Set<String> FLAGS_STRUCTURE = FLAGS_CLASS;
+        private static final Set<String> FLAGS_TOPIC = set("ABSTRACT", "FINAL");
+
+        static ParseResult parseHeaderEndingAtTail(List<Token> toks) {
+            if (toks == null || toks.isEmpty()) return null;
+
+            ParseResult r = tryViewTopicSuffix(toks);
+            if (r != null) return r;
+
+            r = tryHeaderSuffix(toks, T.TOPIC, FLAGS_TOPIC, Kind.TOPIC);
+            if (r != null) return r;
+
+            r = tryHeaderSuffix(toks, T.CLASS, FLAGS_CLASS, Kind.CLASS);
+            if (r != null) return r;
+
+            r = tryHeaderSuffix(toks, T.STRUCTURE, FLAGS_STRUCTURE, Kind.STRUCTURE);
+            if (r != null) return r;
+
+            r = tryModelSuffix(toks);
+            return r;
+        }
+
+        private static ParseResult tryViewTopicSuffix(List<Token> toks) {
+            int n = toks.size();
+            for (int i = n - 1; i >= 1; i--) {
+                Token tView = toks.get(i - 1);
+                Token tTopic = toks.get(i);
+                if (tView.t != T.VIEW || tTopic.t != T.TOPIC) continue;
+                int p = i + 1;
+                if (p >= n || toks.get(p).t != T.IDENT) continue;
+                String name = toks.get(p).text;
+                int namePos = toks.get(p).pos;
+                int nameLen = name.length();
+                p++;
+                if (p == n) {
+                    return new ParseResult(Kind.VIEW_TOPIC, name, tView.pos, namePos, nameLen);
+                }
+            }
+            return null;
+        }
+
+        private static ParseResult tryHeaderSuffix(List<Token> toks, T keyword,
+                                                   Set<String> allowedFlags, Kind kind) {
+            int n = toks.size();
+            for (int i = n - 1; i >= 0; i--) {
+                Token kw = toks.get(i);
+                if (kw.t != keyword) continue;
+                int p = i + 1;
+                if (p >= n || toks.get(p).t != T.IDENT) continue;
+                String name = toks.get(p).text;
+                int namePos = toks.get(p).pos;
+                int nameLen = name.length();
+                p++;
+
+                int p2 = parseOptionalFlags(toks, p, allowedFlags);
+                if (p2 == -1) continue;
+                p = p2;
+
+                if (p < n && toks.get(p).t == T.EXTENDS) {
+                    p++;
+                    int q = parseQualifiedIdent(toks, p);
+                    if (q == -1) continue;
+                    p = q;
+                }
+
+                if (p == n) {
+                    return new ParseResult(kind, name, kw.pos, namePos, nameLen);
+                }
+            }
+            return null;
+        }
+
+        private static ParseResult tryModelSuffix(List<Token> toks) {
+            int n = toks.size();
+            for (int i = n - 1; i >= 0; i--) {
+                Token kw = toks.get(i);
+                if (kw.t != T.MODEL) continue;
+                int p = i + 1;
+                if (p >= n || toks.get(p).t != T.IDENT) continue;
+                String name = toks.get(p).text;
+                int namePos = toks.get(p).pos;
+                int nameLen = name.length();
+                p++;
+                if (p == n) {
+                    return new ParseResult(Kind.MODEL, name, kw.pos, namePos, nameLen);
+                }
+            }
+            return null;
+        }
+
+        private static int parseOptionalFlags(List<Token> toks, int p, Set<String> allowed) {
+            int n = toks.size();
+            if (p >= n || toks.get(p).t != T.LPAREN) return p;
+
+            int q = p + 1;
+            if (q >= n || !isAllowedFlag(toks.get(q), allowed)) return -1;
+            q++;
+            while (q < n && toks.get(q).t == T.COMMA) {
+                q++;
+                if (q >= n || !isAllowedFlag(toks.get(q), allowed)) return -1;
+                q++;
+            }
+            if (q >= n || toks.get(q).t != T.RPAREN) return -1;
+
+            return q + 1;
+        }
+
+        private static int parseQualifiedIdent(List<Token> toks, int p) {
+            int n = toks.size();
+            if (p >= n || toks.get(p).t != T.IDENT) return -1;
+            p++;
+            while (p + 1 < n && toks.get(p).t == T.DOT && toks.get(p + 1).t == T.IDENT) {
+                p += 2;
+            }
+            return p;
+        }
+
+        private static boolean isAllowedFlag(Token tk, Set<String> allowed) {
+            return tk.t == T.IDENT && allowed.contains(tk.text);
+        }
+
+        private static Set<String> set(String... s) {
+            Set<String> out = new HashSet<>();
+            Collections.addAll(out, s);
+            return out;
+        }
+    }
+}
+

--- a/src/main/java/ch/so/agi/lsp/interlis/InterlisLanguageServer.java
+++ b/src/main/java/ch/so/agi/lsp/interlis/InterlisLanguageServer.java
@@ -48,6 +48,9 @@ public class InterlisLanguageServer implements LanguageServer, LanguageClientAwa
         caps.setPositionEncoding(org.eclipse.lsp4j.PositionEncodingKind.UTF16);
         caps.setDocumentFormattingProvider(true);
 
+        DocumentOnTypeFormattingOptions onType = new DocumentOnTypeFormattingOptions("=");
+        caps.setDocumentOnTypeFormattingProvider(onType);
+
         InitializeResult result = new InitializeResult(caps);
         return CompletableFuture.completedFuture(result);
     }

--- a/src/test/java/ch/so/agi/lsp/interlis/DocumentTrackerTest.java
+++ b/src/test/java/ch/so/agi/lsp/interlis/DocumentTrackerTest.java
@@ -1,0 +1,74 @@
+package ch.so.agi.lsp.interlis;
+
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.Range;
+import org.eclipse.lsp4j.TextDocumentContentChangeEvent;
+import org.eclipse.lsp4j.TextDocumentItem;
+import org.eclipse.lsp4j.VersionedTextDocumentIdentifier;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class DocumentTrackerTest {
+
+    @Test
+    void openStoresInitialContents() {
+        DocumentTracker tracker = new DocumentTracker();
+        TextDocumentItem item = new TextDocumentItem("file:///doc.ili", "INTERLIS", 1, "CLASS Foo =");
+        tracker.open(item);
+
+        assertEquals("CLASS Foo =", tracker.getText("file:///doc.ili"));
+        assertEquals(1, tracker.getVersion("file:///doc.ili"));
+    }
+
+    @Test
+    void applyIncrementalChangesUpdatesText() {
+        DocumentTracker tracker = new DocumentTracker();
+        TextDocumentItem item = new TextDocumentItem("file:///doc.ili", "INTERLIS", 1, "Hello\nWorld");
+        tracker.open(item);
+
+        VersionedTextDocumentIdentifier id = new VersionedTextDocumentIdentifier("file:///doc.ili", 2);
+        TextDocumentContentChangeEvent change = new TextDocumentContentChangeEvent();
+        change.setRange(new Range(new Position(1, 0), new Position(1, 5)));
+        change.setText("Interlis");
+
+        tracker.applyChanges(id, List.of(change));
+
+        assertEquals("Hello\nInterlis", tracker.getText("file:///doc.ili"));
+        assertEquals(2, tracker.getVersion("file:///doc.ili"));
+    }
+
+    @Test
+    void applyFullDocumentSyncReplacesContent() {
+        DocumentTracker tracker = new DocumentTracker();
+        TextDocumentItem item = new TextDocumentItem("file:///doc.ili", "INTERLIS", 1, "old");
+        tracker.open(item);
+
+        VersionedTextDocumentIdentifier id = new VersionedTextDocumentIdentifier("file:///doc.ili", 3);
+        TextDocumentContentChangeEvent change = new TextDocumentContentChangeEvent();
+        change.setText("new text");
+
+        tracker.applyChanges(id, List.of(change));
+
+        assertEquals("new text", tracker.getText("file:///doc.ili"));
+        assertEquals(3, tracker.getVersion("file:///doc.ili"));
+    }
+
+    @Test
+    void toOffsetAndPositionAtRoundTrip() {
+        String text = "line1\r\nline2\nlast";
+        int offset = DocumentTracker.toOffset(text, new Position(1, 3));
+        Position pos = DocumentTracker.positionAt(text, offset);
+        assertEquals(1, pos.getLine());
+        assertEquals(3, pos.getCharacter());
+    }
+
+    @Test
+    void lineStartOffsetFindsRequestedLine() {
+        String text = "a\n\nbcd\n";
+        assertEquals(3, DocumentTracker.lineStartOffset(text, 2));
+        assertEquals(text.length(), DocumentTracker.lineStartOffset(text, 10));
+    }
+}

--- a/src/test/java/ch/so/agi/lsp/interlis/InterlisAutoCloserTest.java
+++ b/src/test/java/ch/so/agi/lsp/interlis/InterlisAutoCloserTest.java
@@ -1,0 +1,91 @@
+package ch.so.agi.lsp.interlis;
+
+import org.eclipse.lsp4j.DocumentOnTypeFormattingParams;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.Range;
+import org.eclipse.lsp4j.TextDocumentIdentifier;
+import org.eclipse.lsp4j.TextEdit;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class InterlisAutoCloserTest {
+
+    @Test
+    void returnsEmptyWhenTriggerIsNotEquals() {
+        DocumentOnTypeFormattingParams params = params(0, 0, ";");
+        List<TextEdit> edits = InterlisAutoCloser.computeEdits("CLASS Foo =", params);
+        assertTrue(edits.isEmpty());
+    }
+
+    @Test
+    void classHeaderGetsBlankLineAndEnd() {
+        String text = "  CLASS Foo =";
+        DocumentOnTypeFormattingParams params = params(0, text.length(), "=");
+
+        List<TextEdit> edits = InterlisAutoCloser.computeEdits(text, params);
+        assertEquals(1, edits.size());
+
+        TextEdit edit = edits.get(0);
+        assertEquals(new Range(new Position(0, text.length()), new Position(0, text.length())), edit.getRange());
+        assertEquals("\n  " + InterlisAutoCloser.CARET_SENTINEL + "\n  END Foo;", edit.getNewText());
+    }
+
+    @Test
+    void viewTopicHeaderGetsDependsOnBlock() {
+        String text = "VIEW TOPIC TopicA =";
+        DocumentOnTypeFormattingParams params = params(0, text.length(), "=");
+
+        List<TextEdit> edits = InterlisAutoCloser.computeEdits(text, params);
+        assertEquals(1, edits.size());
+        assertEquals("\nDEPENDS ON " + InterlisAutoCloser.CARET_SENTINEL + "\n\nEND TopicA;", edits.get(0).getNewText());
+    }
+
+    @Test
+    void modelHeaderProducesTemplate() {
+        String text = "INTERLIS 2.4;\n\nMODEL ModelA =";
+        DocumentOnTypeFormattingParams params = params(2, "MODEL ModelA =".length(), "=");
+
+        List<TextEdit> edits = InterlisAutoCloser.computeEdits(text, params);
+        assertEquals(2, edits.size());
+
+        TextEdit banner = edits.get(0);
+        assertEquals(new Position(2, 0), banner.getRange().getStart());
+        assertEquals(banner.getRange().getStart(), banner.getRange().getEnd());
+
+        String today = LocalDate.now(ZoneId.of("Europe/Zurich")).format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+        String expectedBanner = "/** !!------------------------------------------------------------------------------\n" +
+                " * !! Version    | wer | Änderung\n" +
+                " * !!------------------------------------------------------------------------------\n" +
+                " * !! " + today + " | abr  | Initalversion\n" +
+                " * !!==============================================================================\n" +
+                " */\n" +
+                "!!@ technicalContact=mailto:acme@example.com\n" +
+                "!!@ furtherInformation=https://example.com/path/to/information\n" +
+                "!!@ title=\"a title\"\n" +
+                "!!@ shortDescription=\"a short description\"\n" +
+                "!!@ tags=\"foo,bar,fubar\"\n";
+        assertEquals(expectedBanner, banner.getNewText());
+
+        TextEdit mid = edits.get(1);
+        assertEquals(" (de)\n" +
+                "  AT \"https://example.com\"\n" +
+                "  VERSION \"" + today + "\"\n" +
+                "  =\n" +
+                InterlisAutoCloser.CARET_SENTINEL + "\n" +
+                "END ModelA.", mid.getNewText());
+    }
+
+    private static DocumentOnTypeFormattingParams params(int line, int character, String ch) {
+        DocumentOnTypeFormattingParams params = new DocumentOnTypeFormattingParams();
+        params.setCh(ch);
+        params.setPosition(new Position(line, character));
+        params.setTextDocument(new TextDocumentIdentifier("file:///doc.ili"));
+        return params;
+    }
+}


### PR DESCRIPTION
## Summary
- add coverage for DocumentTracker's open/change helpers and position math
- verify the auto-closer generates edits for CLASS/VIEW TOPIC/MODEL headers
- embed a caret sentinel in auto-closer edits and teach the VS Code client to reposition the cursor when it appears

## Testing
- ./gradlew test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dad8f21f1c832883bbd8a7079e1784