### PR TITLE
Extract definition finder and add tests

### DIFF
--- a/src/main/java/ch/so/agi/lsp/interlis/InterlisDefinitionFinder.java
+++ b/src/main/java/ch/so/agi/lsp/interlis/InterlisDefinitionFinder.java
@@ -1,0 +1,157 @@
+package ch.so.agi.lsp.interlis;
+
+import ch.interlis.ili2c.metamodel.Model;
+import ch.interlis.ili2c.metamodel.TransferDescription;
+import org.eclipse.lsp4j.Location;
+import org.eclipse.lsp4j.LocationLink;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.Range;
+import org.eclipse.lsp4j.TextDocumentPositionParams;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+final class InterlisDefinitionFinder {
+    private static final Logger LOG = LoggerFactory.getLogger(InterlisDefinitionFinder.class);
+
+    private final InterlisLanguageServer server;
+    private final DocumentTracker documents;
+
+    InterlisDefinitionFinder(InterlisLanguageServer server, DocumentTracker documents) {
+        this.server = server;
+        this.documents = documents;
+    }
+
+    Either<List<? extends Location>, List<? extends LocationLink>> findDefinition(TextDocumentPositionParams params) throws Exception {
+        if (params == null || params.getTextDocument() == null) {
+            return Either.forLeft(Collections.emptyList());
+        }
+
+        String uri = params.getTextDocument().getUri();
+        if (uri == null || uri.isEmpty()) {
+            return Either.forLeft(Collections.emptyList());
+        }
+
+        String text = documents != null ? documents.getText(uri) : null;
+        if (text == null || text.isEmpty()) {
+            text = InterlisTextDocumentService.readDocument(uri);
+        }
+        if (text == null || text.isEmpty()) {
+            return Either.forLeft(Collections.emptyList());
+        }
+
+        Position position = params.getPosition();
+        int offset = DocumentTracker.toOffset(text, position);
+
+        int start = offset;
+        while (start > 0 && isIdentifierPart(text.charAt(start - 1))) {
+            start--;
+        }
+
+        int end = offset;
+        int length = text.length();
+        while (end < length && isIdentifierPart(text.charAt(end))) {
+            end++;
+        }
+
+        if (start >= end) {
+            return Either.forLeft(Collections.emptyList());
+        }
+
+        String token = text.substring(start, end);
+        if (token.isEmpty()) {
+            return Either.forLeft(Collections.emptyList());
+        }
+
+        String pathOrUri = InterlisTextDocumentService.toFilesystemPathIfPossible(uri);
+        ClientSettings cfg = server.getClientSettings();
+        Ili2cUtil.CompilationOutcome outcome = Ili2cUtil.compile(cfg, pathOrUri);
+        TransferDescription td = outcome.getTransferDescription();
+        if (td == null) {
+            return Either.forLeft(Collections.emptyList());
+        }
+
+        String targetPath = resolveModelPath(td, token);
+        if (targetPath == null || targetPath.isBlank()) {
+            return Either.forLeft(Collections.emptyList());
+        }
+
+        Location location = buildLocation(targetPath, token);
+        if (location == null) {
+            return Either.forLeft(Collections.emptyList());
+        }
+
+        List<Location> locations = new ArrayList<>();
+        locations.add(location);
+        return Either.forLeft(locations);
+    }
+
+    private static boolean isIdentifierPart(char ch) {
+        return Character.isLetterOrDigit(ch) || ch == '_';
+    }
+
+    private static String resolveModelPath(TransferDescription td, String name) {
+        if (td == null || name == null || name.isBlank()) {
+            return null;
+        }
+
+        for (Model model : td.getModelsFromLastFile()) {
+            if (model == null) {
+                continue;
+            }
+
+            if (Objects.equals(name, model.getName())) {
+                return model.getFileName();
+            }
+
+            Model[] imports = model.getImporting();
+            if (imports != null) {
+                for (Model imp : imports) {
+                    if (imp != null && Objects.equals(name, imp.getName())) {
+                        return imp.getFileName();
+                    }
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private Location buildLocation(String pathOrUri, String token) {
+        if (pathOrUri == null || pathOrUri.isBlank()) {
+            return null;
+        }
+
+        try {
+            String normalizedPath = InterlisTextDocumentService.toFilesystemPathIfPossible(pathOrUri);
+            Path path = Paths.get(normalizedPath);
+            String targetText = Files.exists(path) ? Files.readString(path) : "";
+
+            Position start = new Position(0, 0);
+            Position end = start;
+
+            if (!token.isBlank() && !targetText.isEmpty()) {
+                int idx = targetText.indexOf(token);
+                if (idx >= 0) {
+                    start = DocumentTracker.positionAt(targetText, idx);
+                    end = DocumentTracker.positionAt(targetText, idx + token.length());
+                }
+            }
+
+            Range range = new Range(start, end);
+            String targetUri = path.toUri().toString();
+            return new Location(targetUri, range);
+        } catch (Exception ex) {
+            LOG.warn("Failed to build definition location for {}", pathOrUri, ex);
+            return null;
+        }
+    }
+}

--- a/src/main/java/ch/so/agi/lsp/interlis/InterlisDefinitionFinder.java
+++ b/src/main/java/ch/so/agi/lsp/interlis/InterlisDefinitionFinder.java
@@ -1,5 +1,6 @@
 package ch.so.agi.lsp.interlis;
 
+import ch.interlis.ili2c.metamodel.Element;
 import ch.interlis.ili2c.metamodel.Model;
 import ch.interlis.ili2c.metamodel.TransferDescription;
 import org.eclipse.lsp4j.Location;
@@ -11,6 +12,7 @@ import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -18,16 +20,39 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
 final class InterlisDefinitionFinder {
     private static final Logger LOG = LoggerFactory.getLogger(InterlisDefinitionFinder.class);
 
     private final InterlisLanguageServer server;
     private final DocumentTracker documents;
+    private final CompilationProvider compiler;
+    private final ConcurrentMap<String, CachedCompilation> compilationCache = new ConcurrentHashMap<>();
+
+    interface CompilationProvider {
+        Ili2cUtil.CompilationOutcome compile(ClientSettings settings, String fileUriOrPath);
+    }
+
+    private static final class CachedCompilation {
+        final Integer version;
+        final Ili2cUtil.CompilationOutcome outcome;
+
+        CachedCompilation(Integer version, Ili2cUtil.CompilationOutcome outcome) {
+            this.version = version;
+            this.outcome = outcome;
+        }
+    }
 
     InterlisDefinitionFinder(InterlisLanguageServer server, DocumentTracker documents) {
+        this(server, documents, Ili2cUtil::compile);
+    }
+
+    InterlisDefinitionFinder(InterlisLanguageServer server, DocumentTracker documents, CompilationProvider compiler) {
         this.server = server;
         this.documents = documents;
+        this.compiler = compiler;
     }
 
     Either<List<? extends Location>, List<? extends LocationLink>> findDefinition(TextDocumentPositionParams params) throws Exception {
@@ -48,43 +73,33 @@ final class InterlisDefinitionFinder {
             return Either.forLeft(Collections.emptyList());
         }
 
-        Position position = params.getPosition();
-        int offset = DocumentTracker.toOffset(text, position);
-
-        int start = offset;
-        while (start > 0 && isIdentifierPart(text.charAt(start - 1))) {
-            start--;
-        }
-
-        int end = offset;
-        int length = text.length();
-        while (end < length && isIdentifierPart(text.charAt(end))) {
-            end++;
-        }
-
-        if (start >= end) {
-            return Either.forLeft(Collections.emptyList());
-        }
-
-        String token = text.substring(start, end);
-        if (token.isEmpty()) {
+        TokenContext token = extractToken(text, DocumentTracker.toOffset(text, params.getPosition()));
+        if (token == null || token.segments.isEmpty()) {
             return Either.forLeft(Collections.emptyList());
         }
 
         String pathOrUri = InterlisTextDocumentService.toFilesystemPathIfPossible(uri);
-        ClientSettings cfg = server.getClientSettings();
-        Ili2cUtil.CompilationOutcome outcome = Ili2cUtil.compile(cfg, pathOrUri);
+        Integer version = documents != null ? documents.getVersion(uri) : null;
+        Ili2cUtil.CompilationOutcome outcome = getOrCompile(pathOrUri, version);
         TransferDescription td = outcome.getTransferDescription();
         if (td == null) {
             return Either.forLeft(Collections.emptyList());
         }
 
-        String targetPath = resolveModelPath(td, token);
+        Element element = resolveElement(td, token);
+        if (element != null) {
+            Location location = buildLocation(element);
+            if (location != null) {
+                return Either.forLeft(Collections.singletonList(location));
+            }
+        }
+
+        String targetPath = resolveModelPath(td, token.primarySegment());
         if (targetPath == null || targetPath.isBlank()) {
             return Either.forLeft(Collections.emptyList());
         }
 
-        Location location = buildLocation(targetPath, token);
+        Location location = buildLocation(targetPath, token.primarySegment());
         if (location == null) {
             return Either.forLeft(Collections.emptyList());
         }
@@ -94,8 +109,106 @@ final class InterlisDefinitionFinder {
         return Either.forLeft(locations);
     }
 
+    void cacheCompilation(String uri, Ili2cUtil.CompilationOutcome outcome) {
+        if (uri == null || outcome == null) {
+            return;
+        }
+        String key = InterlisTextDocumentService.toFilesystemPathIfPossible(uri);
+        compilationCache.put(key, new CachedCompilation(documents != null ? documents.getVersion(uri) : null, outcome));
+    }
+
+    void evictCompilation(String uri) {
+        if (uri == null) {
+            return;
+        }
+        String key = InterlisTextDocumentService.toFilesystemPathIfPossible(uri);
+        compilationCache.remove(key);
+    }
+
+    private Ili2cUtil.CompilationOutcome getOrCompile(String pathOrUri, Integer version) {
+        if (pathOrUri == null || pathOrUri.isBlank()) {
+            return new Ili2cUtil.CompilationOutcome(null, "", Collections.emptyList());
+        }
+
+        CachedCompilation cached = compilationCache.get(pathOrUri);
+        if (cached != null && Objects.equals(cached.version, version) && cached.outcome != null) {
+            return cached.outcome;
+        }
+
+        ClientSettings cfg = server.getClientSettings();
+        Ili2cUtil.CompilationOutcome outcome = compiler.compile(cfg, pathOrUri);
+        compilationCache.put(pathOrUri, new CachedCompilation(version, outcome));
+        return outcome;
+    }
+
     private static boolean isIdentifierPart(char ch) {
         return Character.isLetterOrDigit(ch) || ch == '_';
+    }
+
+    private static boolean isQualifiedIdentifierChar(char ch) {
+        return isIdentifierPart(ch) || ch == '.';
+    }
+
+    private static TokenContext extractToken(String text, int offset) {
+        if (text == null || text.isEmpty()) {
+            return null;
+        }
+
+        int start = clamp(offset, 0, text.length());
+        while (start > 0 && isQualifiedIdentifierChar(text.charAt(start - 1))) {
+            start--;
+        }
+
+        int end = clamp(offset, 0, text.length());
+        while (end < text.length() && isQualifiedIdentifierChar(text.charAt(end))) {
+            end++;
+        }
+
+        if (start >= end) {
+            return null;
+        }
+
+        String raw = text.substring(start, end);
+        if (raw.isEmpty()) {
+            return null;
+        }
+
+        List<String> segments = new ArrayList<>();
+        int segmentStart = 0;
+        for (int i = 0; i <= raw.length(); i++) {
+            if (i == raw.length() || raw.charAt(i) == '.') {
+                if (i > segmentStart) {
+                    segments.add(raw.substring(segmentStart, i));
+                }
+                segmentStart = i + 1;
+            }
+        }
+
+        if (segments.isEmpty()) {
+            return null;
+        }
+
+        int cursorInToken = clamp(offset - start, 0, raw.length());
+        if (cursorInToken == raw.length() && cursorInToken > 0) {
+            cursorInToken--;
+        }
+        if (cursorInToken >= 0 && cursorInToken < raw.length() && raw.charAt(cursorInToken) == '.' && cursorInToken > 0) {
+            cursorInToken--;
+        }
+
+        int activeSegment = 0;
+        int accumulatedLength = 0;
+        for (int i = 0; i < segments.size(); i++) {
+            int segmentLength = segments.get(i).length();
+            if (cursorInToken < accumulatedLength + segmentLength) {
+                activeSegment = i;
+                break;
+            }
+            accumulatedLength += segmentLength + 1; // include '.'
+            activeSegment = i;
+        }
+
+        return new TokenContext(raw, segments, activeSegment);
     }
 
     private static String resolveModelPath(TransferDescription td, String name) {
@@ -125,6 +238,33 @@ final class InterlisDefinitionFinder {
         return null;
     }
 
+    private Element resolveElement(TransferDescription td, TokenContext token) {
+        if (td == null || token == null) {
+            return null;
+        }
+
+        for (int end = token.activeSegment; end >= 0; end--) {
+            String candidate = joinSegments(token.segments, end);
+            if (candidate.isBlank()) {
+                continue;
+            }
+            Element element = td.getElement(candidate);
+            if (element != null) {
+                return element;
+            }
+        }
+
+        return null;
+    }
+
+    private static String joinSegments(List<String> segments, int endInclusive) {
+        if (segments == null || segments.isEmpty() || endInclusive < 0) {
+            return "";
+        }
+        int limit = Math.min(endInclusive + 1, segments.size());
+        return String.join(".", segments.subList(0, limit));
+    }
+
     private Location buildLocation(String pathOrUri, String token) {
         if (pathOrUri == null || pathOrUri.isBlank()) {
             return null;
@@ -152,6 +292,87 @@ final class InterlisDefinitionFinder {
         } catch (Exception ex) {
             LOG.warn("Failed to build definition location for {}", pathOrUri, ex);
             return null;
+        }
+    }
+
+    private Location buildLocation(Element element) {
+        if (element == null) {
+            return null;
+        }
+
+        String fileName;
+        if (element instanceof Model) {
+            fileName = ((Model) element).getFileName();
+        } else {
+            Model container = (Model) element.getContainer(Model.class);
+            fileName = container != null ? container.getFileName() : null;
+        }
+
+        if (fileName == null || fileName.isBlank()) {
+            return null;
+        }
+
+        try {
+            String normalizedPath = InterlisTextDocumentService.toFilesystemPathIfPossible(fileName);
+            Path path = Paths.get(normalizedPath).toAbsolutePath();
+            String targetText = Files.exists(path)
+                    ? Files.readString(path, StandardCharsets.UTF_8)
+                    : "";
+
+            Position start = new Position(0, 0);
+            Position end = start;
+
+            if (!targetText.isEmpty()) {
+                int lineNumber = Math.max(element.getSourceLine() - 1, 0);
+                int lineStart = DocumentTracker.lineStartOffset(targetText, lineNumber);
+                int lineEnd = DocumentTracker.lineStartOffset(targetText, lineNumber + 1);
+
+                String name = element.getName();
+                int idx = -1;
+                if (name != null && !name.isBlank()) {
+                    if (lineEnd > lineStart) {
+                        int candidate = targetText.indexOf(name, lineStart);
+                        if (candidate >= lineStart && candidate < lineEnd) {
+                            idx = candidate;
+                        }
+                    }
+                    if (idx < 0) {
+                        idx = targetText.indexOf(name);
+                    }
+                }
+
+                int startOffset = idx >= 0 ? idx : lineStart;
+                int endOffset = idx >= 0 ? idx + (name != null ? name.length() : 0) : Math.max(lineEnd, lineStart);
+
+                start = DocumentTracker.positionAt(targetText, startOffset);
+                end = DocumentTracker.positionAt(targetText, Math.max(endOffset, startOffset));
+            }
+
+            Range range = new Range(start, end);
+            return new Location(path.toUri().toString(), range);
+        } catch (Exception ex) {
+            LOG.warn("Failed to build element definition location for {}", element, ex);
+            return null;
+        }
+    }
+
+    private static int clamp(int value, int min, int max) {
+        return Math.max(min, Math.min(max, value));
+    }
+
+    private static final class TokenContext {
+        final String rawToken;
+        final List<String> segments;
+        final int activeSegment;
+
+        TokenContext(String rawToken, List<String> segments, int activeSegment) {
+            this.rawToken = rawToken;
+            this.segments = segments;
+            this.activeSegment = activeSegment;
+        }
+
+        String primarySegment() {
+            return segments.isEmpty() ? rawToken : segments.get(0);
         }
     }
 }

--- a/src/main/java/ch/so/agi/lsp/interlis/InterlisLanguageServer.java
+++ b/src/main/java/ch/so/agi/lsp/interlis/InterlisLanguageServer.java
@@ -47,6 +47,7 @@ public class InterlisLanguageServer implements LanguageServer, LanguageClientAwa
 
         caps.setPositionEncoding(org.eclipse.lsp4j.PositionEncodingKind.UTF16);
         caps.setDocumentFormattingProvider(true);
+        caps.setDefinitionProvider(true);
 
         DocumentOnTypeFormattingOptions onType = new DocumentOnTypeFormattingOptions("=");
         caps.setDocumentOnTypeFormattingProvider(onType);

--- a/src/main/java/ch/so/agi/lsp/interlis/InterlisTextDocumentService.java
+++ b/src/main/java/ch/so/agi/lsp/interlis/InterlisTextDocumentService.java
@@ -49,6 +49,7 @@ public class InterlisTextDocumentService implements TextDocumentService {
     public void didClose(DidCloseTextDocumentParams params) {
         String uri = params.getTextDocument().getUri();
         server.publishDiagnostics(uri, Collections.emptyList());
+        definitionFinder.evictCompilation(uri);
         documents.close(uri);
     }
 
@@ -102,9 +103,10 @@ public class InterlisTextDocumentService implements TextDocumentService {
                     cfg.getModelRepositoriesList());
 
             Ili2cUtil.CompilationOutcome outcome = Ili2cUtil.compile(cfg, pathOrUri);
+            definitionFinder.cacheCompilation(documentUri, outcome);
 
             server.publishDiagnostics(documentUri, DiagnosticsMapper.toDiagnostics(outcome.getMessages()));
-            server.clearOutput();  
+            server.clearOutput();
             server.logToClient(outcome.getLogText());
         } catch (Exception ex) {
             LOG.error("Validation failed for {} (source={})", documentUri, source, ex);

--- a/src/test/java/ch/so/agi/lsp/interlis/InterlisDefinitionFinderTest.java
+++ b/src/test/java/ch/so/agi/lsp/interlis/InterlisDefinitionFinderTest.java
@@ -1,0 +1,112 @@
+package ch.so.agi.lsp.interlis;
+
+import org.eclipse.lsp4j.Location;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.TextDocumentIdentifier;
+import org.eclipse.lsp4j.TextDocumentItem;
+import org.eclipse.lsp4j.TextDocumentPositionParams;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class InterlisDefinitionFinderTest {
+
+    @Test
+    void resolvesImportedModelToDefinition(@TempDir Path tempDir) throws Exception {
+        Path repositoryDir = Files.createDirectories(tempDir.resolve("models"));
+
+        Path importedModel = repositoryDir.resolve("BaseModel.ili");
+        Files.writeString(importedModel, """
+                INTERLIS 2.3;
+                MODEL BaseModel (en) AT \"http://example.org\" VERSION \"2024-01-01\" =
+                  TOPIC BaseTopic =
+                    CLASS Example =
+                    END Example;
+                  END BaseTopic;
+                END BaseModel.
+                """.stripIndent());
+
+        Path sourceFile = repositoryDir.resolve("UsingModel.ili");
+        String sourceContent = """
+                INTERLIS 2.3;
+                MODEL UsingModel (en) AT \"http://example.org\" VERSION \"2024-01-01\" =
+                  IMPORTS BaseModel;
+                  TOPIC UsingTopic =
+                  END UsingTopic;
+                END UsingModel.
+                """.stripIndent();
+        Files.writeString(sourceFile, sourceContent);
+
+        InterlisLanguageServer server = new InterlisLanguageServer();
+        ClientSettings settings = new ClientSettings();
+        settings.setModelRepositories(repositoryDir.toAbsolutePath().toString());
+        server.setClientSettings(settings);
+
+        DocumentTracker tracker = new DocumentTracker();
+        TextDocumentItem item = new TextDocumentItem(sourceFile.toUri().toString(), "interlis", 1, sourceContent);
+        tracker.open(item);
+
+        InterlisDefinitionFinder finder = new InterlisDefinitionFinder(server, tracker);
+
+        TextDocumentPositionParams params = new TextDocumentPositionParams();
+        params.setTextDocument(new TextDocumentIdentifier(item.getUri()));
+        int tokenOffset = sourceContent.indexOf("BaseModel") + 1; // place cursor within the token
+        Position cursor = DocumentTracker.positionAt(sourceContent, tokenOffset);
+        params.setPosition(cursor);
+
+        Either<List<? extends Location>, List<? extends org.eclipse.lsp4j.LocationLink>> result = finder.findDefinition(params);
+
+        assertTrue(result.isLeft(), "Expected location results");
+        List<? extends Location> locations = result.getLeft();
+        assertEquals(1, locations.size(), "Expected exactly one definition target");
+
+        Location location = locations.get(0);
+        assertEquals(importedModel.toUri().toString(), location.getUri());
+        assertEquals(1, location.getRange().getStart().getLine());
+        assertTrue(location.getRange().getEnd().getCharacter() > location.getRange().getStart().getCharacter());
+    }
+
+    @Test
+    void returnsEmptyWhenModelCannotBeResolved(@TempDir Path tempDir) throws Exception {
+        Path repositoryDir = Files.createDirectories(tempDir.resolve("models"));
+
+        Path sourceFile = repositoryDir.resolve("UsingModel.ili");
+        String sourceContent = """
+                INTERLIS 2.3;
+                MODEL UsingModel (en) AT \"http://example.org\" VERSION \"2024-01-01\" =
+                  IMPORTS MissingModel;
+                  TOPIC UsingTopic =
+                  END UsingTopic;
+                END UsingModel.
+                """.stripIndent();
+        Files.writeString(sourceFile, sourceContent);
+
+        InterlisLanguageServer server = new InterlisLanguageServer();
+        ClientSettings settings = new ClientSettings();
+        settings.setModelRepositories(repositoryDir.toAbsolutePath().toString());
+        server.setClientSettings(settings);
+
+        DocumentTracker tracker = new DocumentTracker();
+        TextDocumentItem item = new TextDocumentItem(sourceFile.toUri().toString(), "interlis", 1, sourceContent);
+        tracker.open(item);
+
+        InterlisDefinitionFinder finder = new InterlisDefinitionFinder(server, tracker);
+
+        TextDocumentPositionParams params = new TextDocumentPositionParams();
+        params.setTextDocument(new TextDocumentIdentifier(item.getUri()));
+        int tokenOffset = sourceContent.indexOf("MissingModel") + 1;
+        Position cursor = DocumentTracker.positionAt(sourceContent, tokenOffset);
+        params.setPosition(cursor);
+
+        Either<List<? extends Location>, List<? extends org.eclipse.lsp4j.LocationLink>> result = finder.findDefinition(params);
+
+        assertTrue(result.isLeft(), "Expected location result arm");
+        assertTrue(result.getLeft().isEmpty(), "Expected no definition locations");
+    }
+}

--- a/src/test/java/ch/so/agi/lsp/interlis/InterlisDefinitionFinderTest.java
+++ b/src/test/java/ch/so/agi/lsp/interlis/InterlisDefinitionFinderTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.io.TempDir;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -68,8 +69,10 @@ class InterlisDefinitionFinderTest {
 
         Location location = locations.get(0);
         assertEquals(importedModel.toUri().toString(), location.getUri());
-        assertEquals(1, location.getRange().getStart().getLine());
-        assertTrue(location.getRange().getEnd().getCharacter() > location.getRange().getStart().getCharacter());
+
+        String importedContent = Files.readString(importedModel);
+        int startOffset = DocumentTracker.toOffset(importedContent, location.getRange().getStart());
+        assertTrue(importedContent.startsWith("BaseModel", startOffset));
     }
 
     @Test
@@ -108,5 +111,125 @@ class InterlisDefinitionFinderTest {
 
         assertTrue(result.isLeft(), "Expected location result arm");
         assertTrue(result.getLeft().isEmpty(), "Expected no definition locations");
+    }
+
+    @Test
+    void resolvesImportedElementWithinModel(@TempDir Path tempDir) throws Exception {
+        Path repositoryDir = Files.createDirectories(tempDir.resolve("models"));
+
+        Path importedModel = repositoryDir.resolve("ImportedModelA.ili");
+        Files.writeString(importedModel, """
+                INTERLIS 2.3;
+                MODEL ImportedModelA (en) AT \"http://example.org\" VERSION \"2024-01-01\" =
+                  TOPIC TopicA =
+                    STRUCTURE StructureB =
+                      attr : TEXT;
+                    END StructureB;
+                  END TopicA;
+                END ImportedModelA.
+                """.stripIndent());
+
+        Path sourceFile = repositoryDir.resolve("RootModel.ili");
+        String sourceContent = """
+                INTERLIS 2.3;
+                MODEL RootModel (en) AT \"http://example.org\" VERSION \"2024-01-01\" =
+                  IMPORTS ImportedModelA;
+                  TOPIC RootTopic =
+                    CLASS Example =
+                      attr1 : ImportedModelA.TopicA.StructureB;
+                    END Example;
+                  END RootTopic;
+                END RootModel.
+                """.stripIndent();
+        Files.writeString(sourceFile, sourceContent);
+
+        InterlisLanguageServer server = new InterlisLanguageServer();
+        ClientSettings settings = new ClientSettings();
+        settings.setModelRepositories(repositoryDir.toAbsolutePath().toString());
+        server.setClientSettings(settings);
+
+        DocumentTracker tracker = new DocumentTracker();
+        TextDocumentItem item = new TextDocumentItem(sourceFile.toUri().toString(), "interlis", 1, sourceContent);
+        tracker.open(item);
+
+        InterlisDefinitionFinder finder = new InterlisDefinitionFinder(server, tracker);
+
+        TextDocumentPositionParams params = new TextDocumentPositionParams();
+        params.setTextDocument(new TextDocumentIdentifier(item.getUri()));
+        int tokenOffset = sourceContent.indexOf("StructureB") + 1;
+        Position cursor = DocumentTracker.positionAt(sourceContent, tokenOffset);
+        params.setPosition(cursor);
+
+        Either<List<? extends Location>, List<? extends org.eclipse.lsp4j.LocationLink>> result = finder.findDefinition(params);
+        assertTrue(result.isLeft());
+        List<? extends Location> locations = result.getLeft();
+        assertEquals(1, locations.size());
+
+        Location location = locations.get(0);
+        assertEquals(importedModel.toUri().toString(), location.getUri());
+
+        String importedContent = Files.readString(importedModel);
+        int startOffset = DocumentTracker.toOffset(importedContent, location.getRange().getStart());
+        assertTrue(importedContent.startsWith("StructureB", startOffset));
+    }
+
+    @Test
+    void reusesCompilationForRepeatedLookups(@TempDir Path tempDir) throws Exception {
+        Path repositoryDir = Files.createDirectories(tempDir.resolve("models"));
+
+        Path importedModel = repositoryDir.resolve("BaseModel.ili");
+        Files.writeString(importedModel, """
+                INTERLIS 2.3;
+                MODEL BaseModel (en) AT \"http://example.org\" VERSION \"2024-01-01\" =
+                  TOPIC BaseTopic =
+                    CLASS Example =
+                    END Example;
+                  END BaseTopic;
+                END BaseModel.
+                """.stripIndent());
+
+        Path sourceFile = repositoryDir.resolve("UsingModel.ili");
+        String sourceContent = """
+                INTERLIS 2.3;
+                MODEL UsingModel (en) AT \"http://example.org\" VERSION \"2024-01-01\" =
+                  IMPORTS BaseModel;
+                  TOPIC UsingTopic =
+                  END UsingTopic;
+                END UsingModel.
+                """.stripIndent();
+        Files.writeString(sourceFile, sourceContent);
+
+        InterlisLanguageServer server = new InterlisLanguageServer();
+        ClientSettings settings = new ClientSettings();
+        settings.setModelRepositories(repositoryDir.toAbsolutePath().toString());
+        server.setClientSettings(settings);
+
+        DocumentTracker tracker = new DocumentTracker();
+        TextDocumentItem item = new TextDocumentItem(sourceFile.toUri().toString(), "interlis", 1, sourceContent);
+        tracker.open(item);
+
+        CountingCompilationProvider compiler = new CountingCompilationProvider();
+        InterlisDefinitionFinder finder = new InterlisDefinitionFinder(server, tracker, compiler);
+
+        TextDocumentPositionParams params = new TextDocumentPositionParams();
+        params.setTextDocument(new TextDocumentIdentifier(item.getUri()));
+        int tokenOffset = sourceContent.indexOf("BaseModel") + 1;
+        Position cursor = DocumentTracker.positionAt(sourceContent, tokenOffset);
+        params.setPosition(cursor);
+
+        finder.findDefinition(params);
+        finder.findDefinition(params);
+
+        assertEquals(1, compiler.invocations.get(), "Expected compile to run only once due to caching");
+    }
+
+    private static final class CountingCompilationProvider implements InterlisDefinitionFinder.CompilationProvider {
+        private final AtomicInteger invocations = new AtomicInteger();
+
+        @Override
+        public Ili2cUtil.CompilationOutcome compile(ClientSettings settings, String fileUriOrPath) {
+            invocations.incrementAndGet();
+            return Ili2cUtil.compile(settings, fileUriOrPath);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- extract the go to definition logic into a dedicated `InterlisDefinitionFinder`
- delegate the text document service to the finder implementation
- add unit tests covering imported model resolution and unresolved imports

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68db86db7c608328aa6c354f58c088d7