### PR TITLE
Add definition lookup for imported model elements

### DIFF
--- a/src/test/java/ch/so/agi/lsp/interlis/InterlisDefinitionFinderTest.java
+++ b/src/test/java/ch/so/agi/lsp/interlis/InterlisDefinitionFinderTest.java
@@ -73,6 +73,69 @@ class InterlisDefinitionFinderTest {
     }
 
     @Test
+    void resolvesQualifiedElementFromImportedModel(@TempDir Path tempDir) throws Exception {
+        Path repositoryDir = Files.createDirectories(tempDir.resolve("models"));
+
+        Path importedModel = repositoryDir.resolve("BaseModel.ili");
+        String baseModelContent = """
+                INTERLIS 2.3;
+                MODEL BaseModel (en) AT \"http://example.org\" VERSION \"2024-01-01\" =
+                  STRUCTURE StructureB =
+                    attr : TEXT;
+                  END StructureB;
+                END BaseModel.
+                """.stripIndent();
+        Files.writeString(importedModel, baseModelContent);
+
+        Path sourceFile = repositoryDir.resolve("UsingModel.ili");
+        String sourceContent = """
+                INTERLIS 2.3;
+                MODEL UsingModel (en) AT \"http://example.org\" VERSION \"2024-01-01\" =
+                  IMPORTS BaseModel;
+                  TOPIC UsingTopic =
+                    CLASS Example =
+                      attr1 : BaseModel.StructureB;
+                    END Example;
+                  END UsingTopic;
+                END UsingModel.
+                """.stripIndent();
+        Files.writeString(sourceFile, sourceContent);
+
+        InterlisLanguageServer server = new InterlisLanguageServer();
+        ClientSettings settings = new ClientSettings();
+        settings.setModelRepositories(repositoryDir.toAbsolutePath().toString());
+        server.setClientSettings(settings);
+
+        DocumentTracker tracker = new DocumentTracker();
+        TextDocumentItem item = new TextDocumentItem(sourceFile.toUri().toString(), "interlis", 1, sourceContent);
+        tracker.open(item);
+
+        InterlisDefinitionFinder finder = new InterlisDefinitionFinder(server, tracker, new CompilationCache());
+
+        TextDocumentPositionParams params = new TextDocumentPositionParams();
+        params.setTextDocument(new TextDocumentIdentifier(item.getUri()));
+        int tokenOffset = sourceContent.indexOf("BaseModel.StructureB") + "BaseModel.".length() + 1;
+        Position cursor = DocumentTracker.positionAt(sourceContent, tokenOffset);
+        params.setPosition(cursor);
+
+        Either<List<? extends Location>, List<? extends org.eclipse.lsp4j.LocationLink>> result = finder.findDefinition(params);
+
+        assertTrue(result.isLeft(), "Expected location results");
+        List<? extends Location> locations = result.getLeft();
+        assertEquals(1, locations.size(), "Expected exactly one definition target");
+
+        Location location = locations.get(0);
+        assertEquals(importedModel.toUri().toString(), location.getUri());
+
+        int definitionOffset = baseModelContent.indexOf("StructureB =");
+        Position expectedStart = DocumentTracker.positionAt(baseModelContent, definitionOffset);
+        Position expectedEnd = DocumentTracker.positionAt(baseModelContent, definitionOffset + "StructureB".length());
+
+        assertEquals(expectedStart, location.getRange().getStart());
+        assertEquals(expectedEnd, location.getRange().getEnd());
+    }
+
+    @Test
     void returnsEmptyWhenModelCannotBeResolved(@TempDir Path tempDir) throws Exception {
         Path repositoryDir = Files.createDirectories(tempDir.resolve("models"));
 


### PR DESCRIPTION
## Summary
- extend the definition finder to treat dots as part of identifiers and resolve qualified names through the compiled transfer description
- locate referenced elements in imported models and compute precise ranges using their metadata with a fallback to existing model lookup
- add a regression test covering references to structured types defined in imported models

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68dd2d8cd8248328b83f6fe0451747aa