### PR TITLE
Add UML diagram generation command

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -35,6 +35,10 @@
       {
         "command": "interlis.compile.run",
         "title": "INTERLIS: Compile current file"
+      },
+      {
+        "command": "interlis.uml.show",
+        "title": "INTERLIS: Show UML class diagram"
       }
     ],
     "configuration": {

--- a/src/main/java/ch/so/agi/lsp/interlis/CommandHandlers.java
+++ b/src/main/java/ch/so/agi/lsp/interlis/CommandHandlers.java
@@ -7,6 +7,8 @@ import org.eclipse.lsp4j.MessageType;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
+import ch.interlis.ili2c.metamodel.TransferDescription;
+
 /** Central place for workspace/executeCommand handlers. */
 public class CommandHandlers {
     private final InterlisLanguageServer server;
@@ -21,7 +23,7 @@ public class CommandHandlers {
             server.getClient().logMessage(new MessageParams(
                 MessageType.Log, "compile called for " + fileUriOrPath));
         }
-        
+
         ClientSettings cfg = server.getClientSettings();
         Ili2cUtil.CompilationOutcome outcome = Ili2cUtil.compile(cfg, fileUriOrPath);
         List<Diagnostic> diagnostics = DiagnosticsMapper.toDiagnostics(outcome.getMessages());
@@ -29,5 +31,34 @@ public class CommandHandlers {
         server.clearOutput();
         server.logToClient(outcome.getLogText());
         return CompletableFuture.completedFuture(outcome.getLogText());
+    }
+
+    /** Compile an .ili file and return an HTML page with the generated Mermaid diagram. */
+    public CompletableFuture<Object> generateUml(String fileUriOrPath) {
+        if (server.getClient() != null) {
+            server.getClient().logMessage(new MessageParams(
+                MessageType.Log, "generateUml called for " + fileUriOrPath));
+        }
+
+        ClientSettings cfg = server.getClientSettings();
+        Ili2cUtil.CompilationOutcome outcome = Ili2cUtil.compile(cfg, fileUriOrPath);
+        List<Diagnostic> diagnostics = DiagnosticsMapper.toDiagnostics(outcome.getMessages());
+        server.publishDiagnostics(fileUriOrPath, diagnostics);
+        server.clearOutput();
+        server.logToClient(outcome.getLogText());
+
+        TransferDescription td = outcome.getTransferDescription();
+        if (td == null) {
+            return CompletableFuture.failedFuture(
+                new IllegalStateException("ili2c did not return a TransferDescription"));
+        }
+
+        try {
+            String mermaid = Ili2Mermaid.render(td);
+            String html = MermaidHtmlRenderer.render(mermaid);
+            return CompletableFuture.completedFuture(html);
+        } catch (Exception e) {
+            return CompletableFuture.failedFuture(e);
+        }
     }
 }

--- a/src/main/java/ch/so/agi/lsp/interlis/Ili2Mermaid.java
+++ b/src/main/java/ch/so/agi/lsp/interlis/Ili2Mermaid.java
@@ -1,0 +1,612 @@
+package ch.so.agi.lsp.interlis;
+
+
+import java.util.*;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import ch.interlis.ili2c.metamodel.AbstractClassDef;
+import ch.interlis.ili2c.metamodel.AreaType;
+import ch.interlis.ili2c.metamodel.AssociationDef;
+import ch.interlis.ili2c.metamodel.AttributeDef;
+import ch.interlis.ili2c.metamodel.Cardinality;
+import ch.interlis.ili2c.metamodel.CompositionType;
+import ch.interlis.ili2c.metamodel.Constraint;
+import ch.interlis.ili2c.metamodel.Container;
+import ch.interlis.ili2c.metamodel.CoordType;
+import ch.interlis.ili2c.metamodel.Domain;
+import ch.interlis.ili2c.metamodel.Element;
+import ch.interlis.ili2c.metamodel.EnumerationType;
+import ch.interlis.ili2c.metamodel.FormattedType;
+import ch.interlis.ili2c.metamodel.Model;
+import ch.interlis.ili2c.metamodel.MultiAreaType;
+import ch.interlis.ili2c.metamodel.MultiCoordType;
+import ch.interlis.ili2c.metamodel.MultiPolylineType;
+import ch.interlis.ili2c.metamodel.MultiSurfaceType;
+import ch.interlis.ili2c.metamodel.NumericType;
+import ch.interlis.ili2c.metamodel.NumericalType;
+import ch.interlis.ili2c.metamodel.ObjectType;
+import ch.interlis.ili2c.metamodel.PolylineType;
+import ch.interlis.ili2c.metamodel.PredefinedModel;
+import ch.interlis.ili2c.metamodel.ReferenceType;
+import ch.interlis.ili2c.metamodel.RoleDef;
+import ch.interlis.ili2c.metamodel.SurfaceType;
+import ch.interlis.ili2c.metamodel.Table;
+import ch.interlis.ili2c.metamodel.TextOIDType;
+import ch.interlis.ili2c.metamodel.TextType;
+import ch.interlis.ili2c.metamodel.Topic;
+import ch.interlis.ili2c.metamodel.TransferDescription;
+import ch.interlis.ili2c.metamodel.Type;
+import ch.interlis.ili2c.metamodel.TypeAlias;
+import ch.interlis.ili2c.metamodel.Viewable;
+
+public final class Ili2Mermaid {
+    private Ili2Mermaid() {
+    }
+
+    /** Entry point. */
+    public static String render(TransferDescription td) {
+        Objects.requireNonNull(td, "TransferDescription is null");
+        Diagram diagram = new Ili2cAdapter().buildDiagram(td);
+        return new MermaidRenderer().render(diagram);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────────
+    // Domain-agnostic diagram model
+    // ─────────────────────────────────────────────────────────────────────────────
+
+    static final class Diagram {
+        final Map<String, Namespace> namespaces = new LinkedHashMap<>(); // key: fully-qualified namespace label
+        final Map<String, Node> nodes = new LinkedHashMap<>(); // key: fully-qualified node name
+        final List<Inheritance> inheritances = new ArrayList<>();
+        final List<Assoc> assocs = new ArrayList<>();
+
+        Namespace getOrCreateNamespace(String label) {
+            return namespaces.computeIfAbsent(label, Namespace::new);
+        }
+    }
+
+    static final class Namespace {
+        final String label; // e.g. "ModelA::TopicB" or just "ModelA" or "<root>"
+        final List<String> nodeOrder = new ArrayList<>(); // store node fqns for deterministic ordering
+
+        Namespace(String label) {
+            this.label = label;
+        }
+    }
+
+    static final class Node {
+        final String fqn; // e.g. Model.Topic.Class or Model.Class
+        final String displayName; // shown inside Mermaid class block (without package)
+        final Set<String> stereotypes; // e.g. Abstract, Structure, Enumeration, External
+        final List<String> attributes; // lines like: name[1] : TypeName
+        final List<String> methods;
+
+        Node(String fqn, String displayName, Set<String> stereotypes) {
+            this.fqn = fqn;
+            this.displayName = displayName;
+            this.stereotypes = stereotypes;
+            this.attributes = new ArrayList<>();
+            this.methods = new ArrayList<>();
+        }
+    }
+
+    static final class Inheritance {
+        final String subFqn; // child
+        final String supFqn; // parent (may be external)
+
+        Inheritance(String subFqn, String supFqn) {
+            this.subFqn = subFqn;
+            this.supFqn = supFqn;
+        }
+    }
+
+    static final class Assoc {
+        final String leftFqn;
+        final String rightFqn;
+        final String leftCard; // e.g. "1", "0..1", "1..*"
+        final String rightCard; // e.g. "*"
+        final String label; // optional text label (e.g., role names)
+
+        Assoc(String leftFqn, String rightFqn, String leftCard, String rightCard, String label) {
+            this.leftFqn = leftFqn;
+            this.rightFqn = rightFqn;
+            this.leftCard = leftCard;
+            this.rightCard = rightCard;
+            this.label = label;
+        }
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────────
+    // Ili2c → Diagram adapter (Visitor-like traversal)
+    // ─────────────────────────────────────────────────────────────────────────────
+
+    static final class Ili2cAdapter {
+        Diagram buildDiagram(TransferDescription td) {
+            Diagram d = new Diagram();
+
+            // 1) Only models from the last file.
+            Model[] lastModels = td.getModelsFromLastFile();
+            if (lastModels == null)
+                lastModels = new Model[0];
+
+            // quick lookup for "is in last file" decisions
+            Set<Model> lastModelSet = Arrays.stream(lastModels).collect(Collectors.toCollection(LinkedHashSet::new));
+
+            // 2) Register namespaces for each model and topic (and root).
+            Namespace root = d.getOrCreateNamespace("<root>");
+
+            // 3) First pass: collect nodes (classes, structures, enumerations, externals
+            // when needed)
+            for (Model m : sortByName(lastModels)) {
+                // Topics
+                for (Topic t : getElements(m, Topic.class)) {
+                    String nsLabel = m.getName() + "::" + t.getName();
+                    d.getOrCreateNamespace(nsLabel); // ensure it exists
+
+                    // Classes/Structures/Associations inside topic
+                    collectViewablesInContainer(d, lastModelSet, m, t);
+
+                    // Enums/domains inside topic
+                    collectDomains(d, lastModelSet, m, t);
+                }
+
+                // Model-level (outside any topic): classes/structures/assocs
+                collectViewablesInContainer(d, lastModelSet, m, m);
+                collectDomains(d, lastModelSet, m, m);
+                collectFunctions(d, m, m);
+            }
+
+            // 4) Second pass: inheritance edges and external parents
+            for (Node n : new ArrayList<>(d.nodes.values())) {
+                Object def = lookupDefinition(td, n.fqn); // our fqn uses names only; we best-effort map back
+                if (def instanceof Table) {
+                    Table tbl = (Table) def;
+                    Element extEl = tbl.getExtending();
+                    Table base = (extEl instanceof Table) ? (Table) extEl : null;
+                    if (base != null) {
+                        String supFqn = fqnOf(base);
+                        // ensure parent node exists; if parent is outside last-file models, mark
+                        // External & place at root
+                        if (!belongsToLastFile(base, lastModelSet)) {
+                            Node ext = d.nodes.get(supFqn);
+                            if (ext == null) {
+                                Node extNode = new Node(supFqn, localName(supFqn), setOf("External"));
+                                d.nodes.put(extNode.fqn, extNode);
+                                root.nodeOrder.add(extNode.fqn);
+                            } else {
+                                ext.stereotypes.add("External");
+                            }
+                        }
+                        d.inheritances.add(new Inheritance(n.fqn, supFqn));
+                    }
+                }
+            }
+
+            // 5) Associations (with cardinalities on both ends)
+            for (Model m : sortByName(lastModels)) {
+                // Topics first
+                for (Topic t : getElements(m, Topic.class)) {
+                    collectAssociations(d, lastModelSet, m, t);
+                }
+                // Model level
+                collectAssociations(d, lastModelSet, m, m);
+            }
+
+            // Sort edges deterministically
+            d.inheritances.sort(Comparator.comparing((Inheritance i) -> i.subFqn).thenComparing(i -> i.supFqn));
+            d.assocs.sort(Comparator.comparing((Assoc a) -> a.leftFqn).thenComparing(a -> a.rightFqn)
+                    .thenComparing(a -> a.label == null ? "" : a.label));
+
+            return d;
+        }
+
+        // ── collection helpers ────────────────────────────────────────────────────
+
+        private void collectFunctions(Diagram d, Model m, Container container) {
+            String namespace = (container instanceof Topic) ? m.getName() + "::" + container.getName() : "<root>";
+            Namespace ns = d.getOrCreateNamespace(namespace);
+            for (ch.interlis.ili2c.metamodel.Function f : getElements(container,
+                    ch.interlis.ili2c.metamodel.Function.class)) {
+                String fqn = fqnOf(m, container, f);
+                Node node = d.nodes.computeIfAbsent(fqn, k -> new Node(k, f.getName(), setOf("Function")));
+                node.stereotypes.add("Function");
+                ns.nodeOrder.add(fqn);
+            }
+        }
+
+        private void collectViewablesInContainer(Diagram d, Set<Model> lastModelSet, Model m, Container container) {
+            String namespace = (container instanceof Topic) ? m.getName() + "::" + container.getName() : "<root>";
+
+            Namespace ns = d.getOrCreateNamespace(namespace);
+
+            for (Viewable v : getElements(container, Viewable.class)) {
+                if (v instanceof AssociationDef) {
+                    // associations handled later to ensure endpoints/nodes exist first
+                    continue;
+                }
+                if (v instanceof Viewable) {
+                    Viewable vw = (Viewable) v;
+                    String fqn = fqnOf(m, container, vw);
+                    Set<String> stereos = new LinkedHashSet<>();
+                    if (vw.isAbstract())
+                        stereos.add("Abstract");
+                    if (vw instanceof Table) {
+                        Table t = (Table) vw;
+                        if (!t.isIdentifiable())
+                            stereos.add("Structure");
+                    } else {
+                        stereos.add("View");
+                    }
+                    Node node = d.nodes.computeIfAbsent(fqn, k -> new Node(k, vw.getName(), stereos));
+                    node.stereotypes.addAll(stereos);
+
+                    // attributes
+                    for (AttributeDef a : getElements(vw, AttributeDef.class)) {
+                        String card = formatCardinality(a.getCardinality());
+                        String typeName = TypeNamer.nameOf(a);
+                        if (!typeName.equalsIgnoreCase("ObjectType")) {
+                            node.attributes.add(a.getName() + "[" + card + "] : " + typeName);
+                        }
+                    }
+
+                    int ci = 1;
+                    for (Constraint c : getElements(vw, Constraint.class)) {
+                        String cname = (c.getName() != null && !c.getName().isEmpty()) ? c.getName()
+                                : ("constraint" + ci++);
+                        node.methods.add(cname + "()");
+                    }
+                    ns.nodeOrder.add(fqn);
+                }
+            }
+        }
+
+        private void collectDomains(Diagram d, Set<Model> lastModelSet, Model m, Container container) {
+            String namespace = (container instanceof Topic) ? m.getName() + "::" + container.getName() : "<root>";
+            Namespace ns = d.getOrCreateNamespace(namespace);
+
+            for (Domain dom : getElements(container, Domain.class)) {
+                Type t = dom.getType();
+                if (t instanceof EnumerationType) {
+                    String fqn = fqnOf(m, container, dom);
+                    Node node = d.nodes.computeIfAbsent(fqn, k -> new Node(k, dom.getName(), setOf("Enumeration")));
+                    node.stereotypes.add("Enumeration");
+                    ns.nodeOrder.add(fqn);
+                }
+            }
+        }
+
+        private void collectAssociations(Diagram d, Set<Model> lastModelSet, Model m, Container container) {
+            for (AssociationDef as : getElements(container, AssociationDef.class)) {
+                List<RoleDef> roles = as.getRoles();
+                if (roles == null || roles.size() != 2)
+                    continue; // only binary associations rendered
+
+                RoleDef a = roles.get(0);
+                RoleDef b = roles.get(1);
+
+                AbstractClassDef aEnd = a.getDestination();
+                AbstractClassDef bEnd = b.getDestination();
+                if (!(aEnd instanceof Table) || !(bEnd instanceof Table))
+                    continue;
+
+                Table aTbl = (Table) aEnd;
+                Table bTbl = (Table) bEnd;
+
+                String left = fqnOf(m, containerOf(aTbl), aTbl);
+                String right = fqnOf(m, containerOf(bTbl), bTbl);
+
+                // Ensure external placeholders for associations if endpoints not in last-file
+                // models
+                if (!belongsToLastFile(aTbl, lastModelSet))
+                    ensureExternalNode(d, aTbl);
+                if (!belongsToLastFile(bTbl, lastModelSet))
+                    ensureExternalNode(d, bTbl);
+
+                String leftCard = formatCardinality(a.getCardinality());
+                String rightCard = formatCardinality(b.getCardinality());
+
+                String label = roleLabel(a) + "–" + roleLabel(b);
+
+                d.assocs.add(new Assoc(left, right, leftCard, rightCard, label));
+            }
+        }
+
+        private void ensureExternalNode(Diagram d, Table t) {
+            String fqn = fqnOf(t);
+            if (!d.nodes.containsKey(fqn)) {
+                Node ext = new Node(fqn, t.getName(), setOf("External"));
+                d.nodes.put(ext.fqn, ext);
+                d.getOrCreateNamespace("<root>").nodeOrder.add(ext.fqn);
+            } else {
+                d.nodes.get(fqn).stereotypes.add("External");
+            }
+        }
+
+        // ── tiny utilities over ili2c model ───────────────────────────────────────
+
+        private static String roleLabel(RoleDef r) {
+            String n = r.getName();
+            return n != null && !n.isEmpty() ? n : "role";
+        }
+
+        private static boolean belongsToLastFile(Element e, Set<Model> lastModels) {
+            return lastModels.contains(modelOf(e));
+        }
+
+        private static Model modelOf(Element e) {
+            Element cur = e;
+            while (cur != null && !(cur instanceof Model)) {
+                cur = cur.getContainer();
+            }
+            return (Model) cur;
+        }
+
+        private static Container containerOf(Element e) {
+            Element cur = e.getContainer();
+            if (cur instanceof Container)
+                return (Container) cur;
+            return null;
+        }
+
+        private static String fqnOf(Model m, Container c, Element e) {
+            if (c instanceof Topic)
+                return m.getName() + "." + c.getName() + "." + e.getName();
+            return m.getName() + "." + e.getName();
+        }
+
+        private static String fqnOf(Element e) {
+            Model m = modelOf(e);
+            Container c = containerOf(e);
+            return fqnOf(m, c, e);
+        }
+
+        private static String localName(String fqn) {
+            int i = fqn.lastIndexOf('.');
+            return i < 0 ? fqn : fqn.substring(i + 1);
+        }
+
+        private static <T extends Element> List<T> getElements(Container c, Class<T> type) {
+            List<T> out = new ArrayList<>();
+            for (Iterator<?> it = c.iterator(); it.hasNext();) {
+                Object e = it.next();
+                if (type.isInstance(e)) {
+                    out.add(type.cast(e));
+                }
+            }
+            out.sort(Comparator.comparing(Element::getName, Comparator.nullsLast(String::compareTo)));
+            return out;
+        }
+
+        private static <T extends Element> List<T> sortByName(T[] arr) {
+            if (arr == null)
+                return List.of();
+
+            return Arrays.stream(arr)
+                    .sorted(Comparator.comparing(Element::getName, Comparator.nullsLast(String::compareTo) // handles
+                                                                                                           // null names
+                    )).collect(Collectors.toList());
+        }
+
+        private static <T extends Element> Function<Element, T> typeSafe() {
+            @SuppressWarnings("unchecked")
+            Function<Element, T> f = e -> (T) e;
+            return f;
+        }
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────────
+    // Mermaid renderer
+    // ─────────────────────────────────────────────────────────────────────────────
+    static final class MermaidRenderer {
+        String render(Diagram d) {
+            StringBuilder sb = new StringBuilder(4_096);
+            sb.append("classDiagram\n");
+
+            // 1) Print namespaces (topics/models). We print classes as we encounter them.
+            d.namespaces.values().forEach(ns -> {
+                if (ns.label.equals("<root>"))
+                    return; // print root nodes later
+                sb.append("  namespace ").append(nsId(ns.label)).append(" {\n");
+                for (String fqn : ns.nodeOrder) {
+                    Node n = d.nodes.get(fqn);
+                    printClassBlock(sb, n, "    ");
+                }
+                sb.append("  }\n");
+            });
+
+            // 2) Root-level nodes (classes outside topics and externals)
+            Namespace root = d.namespaces.get("<root>");
+            if (root != null) {
+                for (String fqn : root.nodeOrder) {
+                    Node n = d.nodes.get(fqn);
+                    printClassBlock(sb, n, "  ");
+                }
+            }
+
+            // 3) Inheritance edges
+            for (Inheritance i : d.inheritances) {
+                sb.append("  ").append(id(i.subFqn)).append(" --|> ").append(id(i.supFqn)).append("\n");
+                ;
+            }
+
+            // 4) Associations with cardinalities on both ends
+            for (Assoc a : d.assocs) {
+                sb.append("  ").append(id(a.leftFqn)).append(" \"").append(a.leftCard).append("\" -- \"")
+                        .append(a.rightCard).append("\" ").append(id(a.rightFqn));
+                if (a.label != null && !a.label.isEmpty())
+                    sb.append(" : ").append(escape(a.label));
+                sb.append("\n");
+            }
+
+            return sb.toString();
+        }
+
+        private static String id(String s) {
+            return s;
+        }
+
+        private static String nsId(String s) {
+            return s.replaceAll("[^A-Za-z0-9_]", "_");
+        }
+
+        private void printClassBlock(StringBuilder sb, Node n, String indent) {
+            sb.append(indent).append("class ").append(id(n.fqn)).append("[\"").append(escape(n.displayName))
+                    .append("\"] {\n");
+            // sb.append(indent).append("class ").append(id(n.fqn)).append(" {\n");
+            for (String stereo : n.stereotypes) {
+                sb.append(indent).append("  ").append("<<").append(stereo).append(">>\n");
+            }
+            for (String attr : n.attributes) {
+                sb.append(indent).append("  ").append(escape(attr)).append("\n");
+            }
+            for (String m : n.methods) {
+                sb.append(indent).append("  ").append(escape(m)).append("\n");
+            }
+            sb.append(indent).append("}\n");
+        }
+
+        private static String quote(String id) {
+            // Mermaid class ids allow dots, but quoting is safer and lets us use dots
+            // freely.
+            return '"' + id + '"';
+        }
+
+        private static String escape(String s) {
+            return s.replace("\"", "\\\"");
+        }
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────────
+    // Type naming and cardinality formatting helpers
+    // ─────────────────────────────────────────────────────────────────────────────
+    static final class TypeNamer {
+        static String nameOf(AttributeDef a) {
+            // Type t = a.getDomainResolvingAliases();
+            Type t = a.getDomain();
+            if (t == null)
+                return "<Unknown>";
+            if (t instanceof ObjectType) {
+                return "ObjectType";
+            } else if (t instanceof ReferenceType) {
+                ReferenceType ref = (ReferenceType) t;
+                AbstractClassDef target = ref.getReferred();
+                if (target != null)
+                    return target.getName();
+            } else if (t instanceof CompositionType) {
+                CompositionType comp = (CompositionType) t;
+                AbstractClassDef target = comp.getComponentType();
+                if (target != null)
+                    return target.getName();
+            } else if (t instanceof SurfaceType) {
+                return "Surface";
+            } else if (t instanceof MultiSurfaceType) {
+                return "MultiSurface";
+            } else if (t instanceof AreaType) {
+                return "Area";
+            } else if (t instanceof MultiAreaType) {
+                return "MultiArea";
+            } else if (t instanceof PolylineType) {
+                return "Polyline";
+            } else if (t instanceof MultiPolylineType) {
+                return "MultiPolyline";
+            } else if (t instanceof CoordType) {
+                NumericalType[] nts = ((CoordType) t).getDimensions();
+                return "Coord" + nts.length;
+            } else if (t instanceof MultiCoordType) {
+                NumericalType[] nts = ((MultiCoordType) t).getDimensions();
+                return "MultiCoord" + nts.length;
+            } else if (t instanceof NumericType) {
+                return "Numeric";
+            } else if (t instanceof TextType) {
+                return "String";
+            } else if (t instanceof EnumerationType) {
+                return a.isDomainBoolean() ? "Boolean" : a.getContainer().getName();
+            } else if (t instanceof FormattedType && isDateOrTime((FormattedType) t)) {
+                FormattedType ft = (FormattedType) t;
+                return ft.getDefinedBaseDomain().getName();
+            } else if (t instanceof TextOIDType) {
+                TextOIDType tt = (TextOIDType) t;
+                Type textOidType = tt.getOIDType();
+                if (textOidType instanceof TypeAlias) {
+                    return ((TypeAlias) textOidType).getAliasing().getName();
+                } else {
+                    return textOidType.getName();
+                }
+            } else if (t instanceof TypeAlias) {
+                TypeAlias ta = (TypeAlias) t;
+                ta.getScopedName();
+                return ta.getAliasing().getName();
+            }
+            String n = t.getName();
+            return (n != null && !n.isEmpty()) ? n : t.getClass().getSimpleName();
+        }
+    }
+
+    private static boolean isDateOrTime(FormattedType formattedType) {
+        Domain baseDomain = formattedType.getDefinedBaseDomain();
+        return baseDomain == PredefinedModel.getInstance().XmlDate
+                || baseDomain == PredefinedModel.getInstance().XmlDateTime
+                || baseDomain == PredefinedModel.getInstance().XmlTime;
+    }
+
+    static String formatCardinality(Cardinality c) {
+        if (c == null)
+            return "1";
+        long min = c.getMinimum();
+        long max = c.getMaximum(); // convention: -1 == unbounded
+
+        String left = String.valueOf(min);
+        String right = (max == Long.MAX_VALUE) ? "*" : String.valueOf(max);
+
+        // Compact: show single value when min==max and not unbounded
+        if (max >= 0 && min == max)
+            return String.valueOf(min);
+        return left + ".." + right;
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────────
+    // Lookup helpers (best-effort; used only for inheritance/external placement)
+    // ─────────────────────────────────────────────────────────────────────────────
+    private static Object lookupDefinition(TransferDescription td, String fqn) {
+        // Map by names. This is best-effort for creating inheritance edges if we
+        // already have the node. Not performance-critical.
+        Map<String, Object> byFqn = new HashMap<>();
+        for (Model m : Optional.ofNullable(td.getModelsFromLastFile()).orElse(new Model[0])) {
+            // topics
+            for (Topic t : getElements(m, Topic.class)) {
+                for (Table tbl : getElements(t, Table.class)) {
+                    byFqn.put(fqnOf(m, t, tbl), tbl);
+                }
+            }
+            // model-level
+            for (Table tbl : getElements(m, Table.class)) {
+                byFqn.put(fqnOf(m, m, tbl), tbl);
+            }
+        }
+        return byFqn.get(fqn);
+    }
+
+    private static <T extends Element> List<T> getElements(Container c, Class<T> type) {
+        List<T> out = new ArrayList<>();
+        for (Iterator<?> it = c.iterator(); it.hasNext();) {
+            Object e = it.next();
+            if (type.isInstance(e)) {
+                out.add(type.cast(e));
+            }
+        }
+        out.sort(Comparator.comparing(Element::getName, Comparator.nullsLast(String::compareTo)));
+        return out;
+    }
+
+    private static String fqnOf(Model m, Container c, Element e) {
+        if (c instanceof Topic)
+            return m.getName() + "." + c.getName() + "." + e.getName();
+        return m.getName() + "." + e.getName();
+    }
+
+    private static Set<String> setOf(String... s) {
+        return new LinkedHashSet<>(Arrays.asList(s));
+    }
+}

--- a/src/main/java/ch/so/agi/lsp/interlis/InterlisLanguageServer.java
+++ b/src/main/java/ch/so/agi/lsp/interlis/InterlisLanguageServer.java
@@ -19,6 +19,7 @@ public class InterlisLanguageServer implements LanguageServer, LanguageClientAwa
     private final AtomicReference<ClientSettings> clientSettings = new AtomicReference<>(new ClientSettings());
 
     public static final String CMD_COMPILE = "interlis.compile"; // workspace/executeCommand
+    public static final String CMD_GENERATE_UML = "interlis.uml";
 
     public InterlisLanguageServer() {
         this.textDocumentService = new InterlisTextDocumentService(this);
@@ -42,7 +43,7 @@ public class InterlisLanguageServer implements LanguageServer, LanguageClientAwa
         SaveOptions save = new SaveOptions(); save.setIncludeText(false); 
         sync.setSave(save);
         
-        ExecuteCommandOptions exec = new ExecuteCommandOptions(Collections.singletonList(CMD_COMPILE));
+        ExecuteCommandOptions exec = new ExecuteCommandOptions(Arrays.asList(CMD_COMPILE, CMD_GENERATE_UML));
         caps.setExecuteCommandProvider(exec);
 
         caps.setPositionEncoding(org.eclipse.lsp4j.PositionEncodingKind.UTF16);

--- a/src/main/java/ch/so/agi/lsp/interlis/MermaidHtmlRenderer.java
+++ b/src/main/java/ch/so/agi/lsp/interlis/MermaidHtmlRenderer.java
@@ -1,0 +1,53 @@
+package ch.so.agi.lsp.interlis;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+/**
+ * Loads the Mermaid HTML template and injects the generated diagram text.
+ */
+public final class MermaidHtmlRenderer {
+    private static final String TEMPLATE_PATH = "/mermaid_template.html";
+    private static final String PLACEHOLDER = "${mermaidString}";
+    private static final String TEMPLATE = loadTemplate();
+
+    private MermaidHtmlRenderer() {
+    }
+
+    public static String render(String mermaidSource) {
+        Objects.requireNonNull(mermaidSource, "mermaidSource must not be null");
+        String escaped = escapeHtml(mermaidSource);
+        return TEMPLATE.replace(PLACEHOLDER, escaped);
+    }
+
+    private static String loadTemplate() {
+        try (InputStream in = MermaidHtmlRenderer.class.getResourceAsStream(TEMPLATE_PATH)) {
+            if (in == null) {
+                throw new IllegalStateException("Could not load Mermaid template from " + TEMPLATE_PATH);
+            }
+            try (BufferedReader reader = new BufferedReader(new InputStreamReader(in, StandardCharsets.UTF_8))) {
+                return reader.lines().collect(Collectors.joining("\n"));
+            }
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to read Mermaid template", e);
+        }
+    }
+
+    private static String escapeHtml(String input) {
+        StringBuilder sb = new StringBuilder(input.length());
+        for (char c : input.toCharArray()) {
+            switch (c) {
+                case '&' -> sb.append("&amp;");
+                case '<' -> sb.append("&lt;");
+                case '>' -> sb.append("&gt;");
+                default -> sb.append(c);
+            }
+        }
+        return sb.toString();
+    }
+}

--- a/src/main/resources/mermaid_template.html
+++ b/src/main/resources/mermaid_template.html
@@ -1,0 +1,150 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>UML class diagram</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <style>
+    html, body { height: 100%; margin: 0; }
+    .page { height: 100%; padding: 16px; box-sizing: border-box; }
+    .diagram-wrap {
+      position: relative; height: 70vh;
+      border: 1px solid #e5e5e5; border-radius: 10px; background: #fafafa;
+      overflow: hidden;
+      height: 100%;
+    }
+    .diagram-toolbar { position: absolute; top: 8px; right: 8px; z-index: 2; display: flex; gap: 6px; }
+    .diagram-toolbar button { padding: 6px 10px; border: 1px solid #d0d0d0; background: #fff; border-radius: 8px; cursor: pointer; }
+
+    /* 2) CSS fallback: kill any Mermaid max-widths */
+    .diagram-wrap svg { width: 100% !important; height: 100% !important; max-width: none !important; }
+    pre.mermaid { display: none; }
+  </style>
+</head>
+<body>
+
+<div class="page">
+  <pre class="mermaid" id="m1">
+${mermaidString}
+  </pre>
+</div>
+
+  <script src="https://cdn.jsdelivr.net/npm/mermaid@11.10.1/dist/mermaid.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/svg-pan-zoom@3.6.1/dist/svg-pan-zoom.min.js"></script>
+
+  <script>
+    mermaid.initialize({
+      startOnLoad: false,
+      securityLevel: 'loose',
+      maxTextSize: 1000000,
+
+      // 1) Ask Mermaid not to force max-width on diagrams
+      flowchart: { useMaxWidth: false },
+      er:        { useMaxWidth: false },
+      sequence:  { useMaxWidth: false },
+      class:     { useMaxWidth: false },       // for classDiagram
+      classDiagram: { useMaxWidth: false },    // (some versions use this key)
+
+      // extra belt-and-suspenders: CSS injection at render time
+      themeCSS: '.mermaid svg{max-width:none !important;height:100% !important;width:100% !important;}'
+    });
+
+    (async function () {
+      var src = document.getElementById('m1');
+      var graphText = src ? src.textContent : '';
+      var out = await mermaid.render('m1-svg', graphText);
+
+      var wrap = document.createElement('div');
+      wrap.className = 'diagram-wrap';
+
+      var toolbar = document.createElement('div');
+      toolbar.className = 'diagram-toolbar';
+      toolbar.innerHTML =
+        '<button type="button" data-a="zin">+</button>' +
+        '<button type="button" data-a="zout">−</button>' +
+        '<button type="button" data-a="fit">Fit</button>' +
+        '<button type="button" data-a="download">Download SVG</button>';
+      wrap.appendChild(toolbar);
+
+      wrap.insertAdjacentHTML('beforeend', out.svg);
+      src.parentNode.replaceChild(wrap, src);
+
+      // 3) Normalize the rendered <svg> just in case
+      var svgEl = wrap.querySelector('svg');
+      if (svgEl) {
+        svgEl.style.maxWidth = 'none';
+        svgEl.style.width = '100%';
+        svgEl.style.height = '100%';
+        // Sometimes Mermaid sets explicit width/height numbers; wipe them
+        svgEl.setAttribute('width', '100%');
+        svgEl.setAttribute('height', '100%');
+      }
+
+      var pz = svgPanZoom(svgEl, {
+        zoomEnabled: true,
+        mouseWheelZoomEnabled: true,
+        controlIconsEnabled: false,
+        fit: true, center: true,
+        minZoom: 0.2, maxZoom: 10,
+        preventMouseEventsDefault: true
+      });
+
+      var STEP = 0.2;
+      toolbar.addEventListener('click', function (e) {
+        var a = e.target && e.target.getAttribute('data-a');
+        if (a === 'zin')  pz.zoomBy(1 + STEP);
+        if (a === 'zout') pz.zoomBy(1 / (1 + STEP));
+        if (a === 'fit')  { pz.resize(); pz.fit(); pz.center(); }
+        if (a === 'download') downloadSVG(svgEl, 'diagram.svg');
+        if (a === 'download-pdf') downloadPDF(svgEl, 'diagram.pdf');
+      });
+
+      window.addEventListener('resize', function () {
+        pz.resize(); pz.fit(); pz.center();
+      }, { passive: true });
+    })();
+
+
+
+function downloadSVG(svgEl, filename) {
+  // Clone so we can tweak without touching the on-page SVG
+  var clone = svgEl.cloneNode(true);
+
+  // Undo svg-pan-zoom’s viewport transform so you get the full diagram
+  var vp = clone.querySelector('.svg-pan-zoom_viewport');
+  if (vp) vp.removeAttribute('transform');
+
+  // Ensure clean sizing (portable in other tools)
+  var vb = clone.getAttribute('viewBox');
+  if (vb) {
+    var p = vb.trim().split(/\s+/);
+    var w = parseFloat(p[2]), h = parseFloat(p[3]);
+    if (!isNaN(w) && !isNaN(h)) {
+      clone.setAttribute('width', w + 'px');
+      clone.setAttribute('height', h + 'px');
+    }
+  }
+  clone.style.maxWidth = 'none';
+  clone.removeAttribute('style'); // drop width:100%/height:100% if present
+
+  // Ensure namespaces for standalone file
+  if (!clone.getAttribute('xmlns')) clone.setAttribute('xmlns', 'http://www.w3.org/2000/svg');
+  if (!clone.getAttribute('xmlns:xlink')) clone.setAttribute('xmlns:xlink', 'http://www.w3.org/1999/xlink');
+
+  // Serialize + download
+  var xml = '<?xml version="1.0" encoding="UTF-8"?>\n' + new XMLSerializer().serializeToString(clone);
+  var blob = new Blob([xml], { type: 'image/svg+xml;charset=utf-8' });
+  var url = URL.createObjectURL(blob);
+  var a = document.createElement('a');
+  a.href = url;
+  a.download = filename || 'diagram.svg';
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  URL.revokeObjectURL(url);
+}
+
+
+  </script>
+</body>
+</html>

--- a/src/main/resources/mermaid_template.html
+++ b/src/main/resources/mermaid_template.html
@@ -6,18 +6,66 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <style>
     html, body { height: 100%; margin: 0; }
-    .page { height: 100%; padding: 16px; box-sizing: border-box; }
-    .diagram-wrap {
-      position: relative; height: 70vh;
-      border: 1px solid #e5e5e5; border-radius: 10px; background: #fafafa;
-      overflow: hidden;
+    body { background: #ffffff; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; color: #333; }
+    .page {
       height: 100%;
+      padding: 16px;
+      box-sizing: border-box;
+      display: grid;
+      grid-template-columns: minmax(0, 2.5fr) minmax(280px, 1fr);
+      gap: 16px;
     }
-    .diagram-toolbar { position: absolute; top: 8px; right: 8px; z-index: 2; display: flex; gap: 6px; }
-    .diagram-toolbar button { padding: 6px 10px; border: 1px solid #d0d0d0; background: #fff; border-radius: 8px; cursor: pointer; }
-
-    /* 2) CSS fallback: kill any Mermaid max-widths */
+    .diagram-pane, .source-pane {
+      border: 1px solid #e5e5e5;
+      border-radius: 10px;
+      background: #fafafa;
+      overflow: hidden;
+      display: flex;
+      flex-direction: column;
+      min-height: 0;
+    }
+    .diagram-wrap {
+      position: relative;
+      flex: 1 1 auto;
+      overflow: hidden;
+    }
+    .diagram-toolbar {
+      position: absolute;
+      top: 8px;
+      right: 8px;
+      z-index: 2;
+      display: flex;
+      gap: 6px;
+    }
+    .diagram-toolbar button {
+      padding: 6px 10px;
+      border: 1px solid #d0d0d0;
+      background: #fff;
+      border-radius: 8px;
+      cursor: pointer;
+    }
     .diagram-wrap svg { width: 100% !important; height: 100% !important; max-width: none !important; }
+    .source-header {
+      padding: 12px 16px;
+      border-bottom: 1px solid #e5e5e5;
+      background: rgba(255, 255, 255, 0.8);
+      font-weight: 600;
+      letter-spacing: 0.02em;
+      text-transform: uppercase;
+      font-size: 12px;
+      color: #5a5a5a;
+    }
+    .source-content {
+      flex: 1 1 auto;
+      overflow: auto;
+      padding: 16px;
+      font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+      font-size: 12px;
+      line-height: 1.5;
+      background: #ffffff;
+      color: #333;
+      white-space: pre;
+    }
     pre.mermaid { display: none; }
   </style>
 </head>
@@ -49,6 +97,8 @@ ${mermaidString}
       themeCSS: '.mermaid svg{max-width:none !important;height:100% !important;width:100% !important;}'
     });
 
+    const vscode = acquireVsCodeApi();
+
     (async function () {
       var src = document.getElementById('m1');
       var graphText = src ? src.textContent : '';
@@ -67,7 +117,23 @@ ${mermaidString}
       wrap.appendChild(toolbar);
 
       wrap.insertAdjacentHTML('beforeend', out.svg);
-      src.parentNode.replaceChild(wrap, src);
+      var page = src.parentNode;
+      page.innerHTML = '';
+
+      var diagramPane = document.createElement('div');
+      diagramPane.className = 'diagram-pane';
+      diagramPane.appendChild(wrap);
+
+      var sourcePane = document.createElement('div');
+      sourcePane.className = 'source-pane';
+      sourcePane.innerHTML = '<div class="source-header">Mermaid source</div>';
+      var sourceContent = document.createElement('pre');
+      sourceContent.className = 'source-content';
+      sourceContent.textContent = graphText.trim();
+      sourcePane.appendChild(sourceContent);
+
+      page.appendChild(diagramPane);
+      page.appendChild(sourcePane);
 
       // 3) Normalize the rendered <svg> just in case
       var svgEl = wrap.querySelector('svg');
@@ -96,7 +162,6 @@ ${mermaidString}
         if (a === 'zout') pz.zoomBy(1 / (1 + STEP));
         if (a === 'fit')  { pz.resize(); pz.fit(); pz.center(); }
         if (a === 'download') downloadSVG(svgEl, 'diagram.svg');
-        if (a === 'download-pdf') downloadPDF(svgEl, 'diagram.pdf');
       });
 
       window.addEventListener('resize', function () {
@@ -131,17 +196,9 @@ function downloadSVG(svgEl, filename) {
   if (!clone.getAttribute('xmlns')) clone.setAttribute('xmlns', 'http://www.w3.org/2000/svg');
   if (!clone.getAttribute('xmlns:xlink')) clone.setAttribute('xmlns:xlink', 'http://www.w3.org/1999/xlink');
 
-  // Serialize + download
+  // Serialize and hand off to the extension for saving
   var xml = '<?xml version="1.0" encoding="UTF-8"?>\n' + new XMLSerializer().serializeToString(clone);
-  var blob = new Blob([xml], { type: 'image/svg+xml;charset=utf-8' });
-  var url = URL.createObjectURL(blob);
-  var a = document.createElement('a');
-  a.href = url;
-  a.download = filename || 'diagram.svg';
-  document.body.appendChild(a);
-  a.click();
-  a.remove();
-  URL.revokeObjectURL(url);
+  vscode.postMessage({ type: 'downloadSvg', filename: filename || 'diagram.svg', svg: xml });
 }
 
 

--- a/src/test/java/ch/so/agi/lsp/interlis/CommandHandlersTest.java
+++ b/src/test/java/ch/so/agi/lsp/interlis/CommandHandlersTest.java
@@ -1,0 +1,46 @@
+package ch.so.agi.lsp.interlis;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class CommandHandlersTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void generateUmlReturnsHtmlFromModel() throws Exception {
+        Path iliFile = tempDir.resolve("SimpleModel.ili");
+        Files.writeString(iliFile, "INTERLIS 2.3;\n" +
+                "MODEL SimpleModel (en)\n" +
+                "AT \"http://example.com/SimpleModel.ili\"\n" +
+                "VERSION \"2024-01-01\" =\n" +
+                "  TOPIC SimpleTopic =\n" +
+                "    CLASS Person =\n" +
+                "    END Person;\n" +
+                "  END SimpleTopic;\n" +
+                "END SimpleModel.\n");
+
+        Ili2cUtil.CompilationOutcome outcome = Ili2cUtil.compile(new ClientSettings(), iliFile.toString());
+        assertNotNull(outcome.getTransferDescription(), outcome.getLogText());
+
+        InterlisLanguageServer server = new InterlisLanguageServer();
+        CommandHandlers handlers = new CommandHandlers(server);
+
+        CompletableFuture<Object> future = handlers.generateUml(iliFile.toString());
+        Object htmlObj = future.get(30, TimeUnit.SECONDS);
+        String html = assertInstanceOf(String.class, htmlObj);
+
+        assertTrue(html.contains("classDiagram"));
+        assertTrue(html.contains("Person"));
+    }
+}

--- a/src/test/java/ch/so/agi/lsp/interlis/MermaidHtmlRendererTest.java
+++ b/src/test/java/ch/so/agi/lsp/interlis/MermaidHtmlRendererTest.java
@@ -1,0 +1,23 @@
+package ch.so.agi.lsp.interlis;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class MermaidHtmlRendererTest {
+
+    @Test
+    void injectsDiagramIntoTemplate() {
+        String html = MermaidHtmlRenderer.render("classDiagram\nclass Foo");
+        assertTrue(html.contains("classDiagram"));
+        assertFalse(html.contains("${mermaidString}"));
+        assertTrue(html.startsWith("<!doctype html>"));
+    }
+
+    @Test
+    void escapesHtmlCharacters() {
+        String html = MermaidHtmlRenderer.render("A < B & C");
+        assertTrue(html.contains("A &lt; B &amp; C"));
+    }
+}

--- a/src/test/java/ch/so/agi/lsp/interlis/MermaidHtmlRendererTest.java
+++ b/src/test/java/ch/so/agi/lsp/interlis/MermaidHtmlRendererTest.java
@@ -13,6 +13,8 @@ class MermaidHtmlRendererTest {
         assertTrue(html.contains("classDiagram"));
         assertFalse(html.contains("${mermaidString}"));
         assertTrue(html.startsWith("<!doctype html>"));
+        assertTrue(html.contains("diagram-pane"));
+        assertTrue(html.contains("Mermaid source"));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- add Ili2Mermaid-based rendering and HTML templating on the server
- expose a new interlis.uml executeCommand and VS Code command to show Mermaid UML diagrams
- cover the renderer and command path with unit tests and include the Mermaid webview template

## Testing
- ./gradlew test
- npm --prefix client run build

------
https://chatgpt.com/codex/tasks/task_e_68dd381b99208328b527fc5ec9be3533