### PR TITLE
Add document symbol support

### DIFF
--- a/src/main/java/ch/so/agi/lsp/interlis/InterlisDocumentSymbolCollector.java
+++ b/src/main/java/ch/so/agi/lsp/interlis/InterlisDocumentSymbolCollector.java
@@ -1,0 +1,224 @@
+package ch.so.agi.lsp.interlis;
+
+import ch.interlis.ili2c.metamodel.AssociationDef;
+import ch.interlis.ili2c.metamodel.AttributeDef;
+import ch.interlis.ili2c.metamodel.Container;
+import ch.interlis.ili2c.metamodel.Domain;
+import ch.interlis.ili2c.metamodel.Element;
+import ch.interlis.ili2c.metamodel.Model;
+import ch.interlis.ili2c.metamodel.Topic;
+import ch.interlis.ili2c.metamodel.TransferDescription;
+import ch.interlis.ili2c.metamodel.View;
+import ch.interlis.ili2c.metamodel.Viewable;
+import ch.interlis.ili2c.metamodel.ViewableTransferElement;
+import ch.interlis.ili2c.metamodel.Table;
+import org.eclipse.lsp4j.DocumentSymbol;
+import org.eclipse.lsp4j.SymbolKind;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.Range;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * Builds {@link DocumentSymbol} hierarchies from an INTERLIS {@link TransferDescription}.
+ */
+final class InterlisDocumentSymbolCollector {
+    private final String documentText;
+
+    InterlisDocumentSymbolCollector(String documentText) {
+        this.documentText = documentText != null ? documentText : "";
+    }
+
+    List<DocumentSymbol> collect(TransferDescription td) {
+        if (td == null) {
+            return Collections.emptyList();
+        }
+
+        List<DocumentSymbol> result = new ArrayList<>();
+        Model[] models = td.getModelsFromLastFile();
+        if (models == null) {
+            return result;
+        }
+
+        Arrays.stream(models)
+                .filter(model -> model != null)
+                .forEach(model -> result.add(buildModelSymbol(model)));
+
+        return result;
+    }
+
+    private DocumentSymbol buildModelSymbol(Model model) {
+        DocumentSymbol symbol = createSymbol(model, "MODEL", SymbolKind.Module);
+        symbol.setChildren(processContainer(model, model));
+        return symbol;
+    }
+
+    private List<DocumentSymbol> processContainer(Container<?> container, Model ownerModel) {
+        List<DocumentSymbol> children = new ArrayList<>();
+        Iterator<?> it = container != null ? container.iterator() : Collections.emptyIterator();
+        while (it.hasNext()) {
+            Object candidate = it.next();
+            if (!(candidate instanceof Element element)) {
+                continue;
+            }
+            if (modelOf(element) != ownerModel) {
+                continue;
+            }
+
+            if (element instanceof Topic topic) {
+                DocumentSymbol topicSymbol = createSymbol(topic, "TOPIC", SymbolKind.Namespace);
+                topicSymbol.setChildren(processContainer(topic, ownerModel));
+                children.add(topicSymbol);
+            } else if (element instanceof Viewable viewable) {
+                DocumentSymbol viewableSymbol = buildViewableSymbol(viewable, ownerModel);
+                if (viewableSymbol != null) {
+                    children.add(viewableSymbol);
+                }
+            } else if (element instanceof Domain domain) {
+                DocumentSymbol domainSymbol = createSymbol(domain, "DOMAIN", SymbolKind.TypeParameter);
+                children.add(domainSymbol);
+            }
+        }
+        return children;
+    }
+
+    private DocumentSymbol buildViewableSymbol(Viewable viewable, Model ownerModel) {
+        String detail = determineViewableDetail(viewable);
+        SymbolKind kind = determineViewableKind(viewable);
+        DocumentSymbol viewableSymbol = createSymbol(viewable, detail, kind);
+        viewableSymbol.setChildren(collectAttributes(viewable, ownerModel));
+        return viewableSymbol;
+    }
+
+    private List<DocumentSymbol> collectAttributes(Viewable viewable, Model ownerModel) {
+        List<DocumentSymbol> attributes = new ArrayList<>();
+        Iterator<ViewableTransferElement> it = viewable.getAttributesAndRoles2();
+        while (it.hasNext()) {
+            ViewableTransferElement vte = it.next();
+            if (!(vte.obj instanceof AttributeDef attribute)) {
+                continue;
+            }
+            if (modelOf(attribute) != ownerModel) {
+                continue;
+            }
+            DocumentSymbol attributeSymbol = createSymbol(attribute, null, SymbolKind.Property);
+            attributes.add(attributeSymbol);
+        }
+        return attributes;
+    }
+
+    private DocumentSymbol createSymbol(Element element, String detail, SymbolKind kind) {
+        String name = element != null ? element.getName() : null;
+        if (name == null) {
+            name = "";
+        }
+        Range lineRange = lineRange(element);
+        Range selection = selectionRange(element, lineRange);
+
+        DocumentSymbol symbol = new DocumentSymbol();
+        symbol.setName(name);
+        symbol.setDetail(detail);
+        symbol.setKind(kind);
+        symbol.setRange(lineRange);
+        symbol.setSelectionRange(selection);
+        return symbol;
+    }
+
+    private Range lineRange(Element element) {
+        int lineIndex = element != null ? Math.max(element.getSourceLine() - 1, 0) : 0;
+        if (documentText.isEmpty()) {
+            Position pos = new Position(lineIndex, 0);
+            return new Range(pos, pos);
+        }
+
+        int startOffset = DocumentTracker.lineStartOffset(documentText, lineIndex);
+        int endOffset = DocumentTracker.lineStartOffset(documentText, lineIndex + 1);
+        if (endOffset < startOffset) {
+            endOffset = documentText.length();
+        }
+        Position start = DocumentTracker.positionAt(documentText, startOffset);
+        Position end = DocumentTracker.positionAt(documentText, endOffset);
+        return new Range(start, end);
+    }
+
+    private Range selectionRange(Element element, Range fallback) {
+        if (element == null) {
+            return fallback;
+        }
+        String name = element.getName();
+        if (name == null || name.isBlank() || documentText.isEmpty()) {
+            return fallback;
+        }
+
+        int sourceLine = Math.max(element.getSourceLine() - 1, 0);
+        int startOffset = DocumentTracker.lineStartOffset(documentText, sourceLine);
+        int endOffset = DocumentTracker.lineStartOffset(documentText, sourceLine + 1);
+        if (endOffset < startOffset) {
+            endOffset = documentText.length();
+        }
+
+        int nameOffset = -1;
+        if (startOffset < documentText.length()) {
+            int safeEnd = Math.min(endOffset, documentText.length());
+            String lineText = documentText.substring(startOffset, safeEnd);
+            int idx = lineText.indexOf(name);
+            if (idx >= 0) {
+                nameOffset = startOffset + idx;
+            }
+        }
+        if (nameOffset < 0) {
+            nameOffset = documentText.indexOf(name);
+        }
+        if (nameOffset < 0) {
+            return fallback;
+        }
+        Position start = DocumentTracker.positionAt(documentText, nameOffset);
+        Position end = DocumentTracker.positionAt(documentText, nameOffset + name.length());
+        return new Range(start, end);
+    }
+
+    private static String determineViewableDetail(Viewable viewable) {
+        if (viewable instanceof Table table) {
+            return table.isIdentifiable() ? "CLASS" : "STRUCTURE";
+        }
+        if (viewable instanceof AssociationDef) {
+            return "ASSOCIATION";
+        }
+        if (viewable instanceof View) {
+            return "VIEW";
+        }
+        return "VIEWABLE";
+    }
+
+    private static SymbolKind determineViewableKind(Viewable viewable) {
+        if (viewable instanceof Table table) {
+            return table.isIdentifiable() ? SymbolKind.Class : SymbolKind.Struct;
+        }
+        if (viewable instanceof AssociationDef) {
+            return SymbolKind.Interface;
+        }
+        if (viewable instanceof View) {
+            return SymbolKind.Interface;
+        }
+        return SymbolKind.Object;
+    }
+
+    private static Model modelOf(Element element) {
+        if (element == null) {
+            return null;
+        }
+        Element current = element;
+        while (current != null) {
+            if (current instanceof Model model) {
+                return model;
+            }
+            Container<?> container = current.getContainer();
+            current = container instanceof Element ? (Element) container : null;
+        }
+        return null;
+    }
+}

--- a/src/main/java/ch/so/agi/lsp/interlis/InterlisLanguageServer.java
+++ b/src/main/java/ch/so/agi/lsp/interlis/InterlisLanguageServer.java
@@ -49,6 +49,7 @@ public class InterlisLanguageServer implements LanguageServer, LanguageClientAwa
         caps.setPositionEncoding(org.eclipse.lsp4j.PositionEncodingKind.UTF16);
         caps.setDocumentFormattingProvider(true);
         caps.setDefinitionProvider(true);
+        caps.setDocumentSymbolProvider(true);
 
         DocumentOnTypeFormattingOptions onType = new DocumentOnTypeFormattingOptions("=");
         caps.setDocumentOnTypeFormattingProvider(onType);

--- a/src/test/java/ch/so/agi/lsp/interlis/InterlisTextDocumentServiceTest.java
+++ b/src/test/java/ch/so/agi/lsp/interlis/InterlisTextDocumentServiceTest.java
@@ -1,19 +1,32 @@
 package ch.so.agi.lsp.interlis;
 
+import ch.interlis.ili2c.metamodel.AttributeDef;
+import ch.interlis.ili2c.metamodel.DataModel;
 import ch.interlis.ili2c.metamodel.Model;
+import ch.interlis.ili2c.metamodel.Table;
+import ch.interlis.ili2c.metamodel.Topic;
 import ch.interlis.ili2c.metamodel.TransferDescription;
+import ch.interlis.ili2c.metamodel.ViewableTransferElement;
+import org.eclipse.lsp4j.DocumentSymbol;
+import org.eclipse.lsp4j.DocumentSymbolParams;
+import org.eclipse.lsp4j.SymbolKind;
 import org.eclipse.lsp4j.DidOpenTextDocumentParams;
+import org.eclipse.lsp4j.SymbolInformation;
+import org.eclipse.lsp4j.TextDocumentIdentifier;
 import org.eclipse.lsp4j.TextDocumentItem;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.*;
 
 class InterlisTextDocumentServiceTest {
 
@@ -103,6 +116,107 @@ class InterlisTextDocumentServiceTest {
         service.didOpen(params);
 
         assertEquals(1, compileCount.get(), "Expected imported model to trigger compilation when opened");
+    }
+
+    @Test
+    void documentSymbolsReflectModelStructure(@TempDir Path tempDir) throws Exception {
+        Path modelPath = Files.createTempFile(tempDir, "ModelOutline", ".ili");
+        String content = String.join("\n",
+                "MODEL ModelOutline;",
+                "TOPIC TopicA =",
+                "  CLASS ClassA =",
+                "    attr1 : TEXT;",
+                "  END ClassA;",
+                "END TopicA;",
+                "END ModelOutline.",
+                "");
+        Files.writeString(modelPath, content);
+
+        DataModel model = new DataModel();
+        model.setName("ModelOutline");
+        model.setFileName(modelPath.toString());
+        model.setSourceLine(1);
+
+        Topic topic = new Topic();
+        topic.setName("TopicA");
+        topic.setSourceLine(2);
+        topic.setContainer(model);
+        model.add(topic);
+
+        TestTable table = new TestTable("ClassA", 3);
+        table.setContainer(topic);
+        topic.add(table);
+
+        AttributeDef attribute = new AttributeDef() {};
+        attribute.setName("attr1");
+        attribute.setSourceLine(4);
+        table.addAttribute(attribute);
+
+        TransferDescription td = new TransferDescription() {
+            @Override
+            public Model[] getModelsFromLastFile() {
+                return new Model[]{model};
+            }
+        };
+
+        Ili2cUtil.CompilationOutcome outcome = new Ili2cUtil.CompilationOutcome(td, "", Collections.emptyList());
+
+        CompilationCache cache = new CompilationCache();
+        cache.put(modelPath.toString(), outcome);
+
+        InterlisLanguageServer server = new InterlisLanguageServer();
+        server.setClientSettings(new ClientSettings());
+
+        InterlisTextDocumentService service = new InterlisTextDocumentService(server, cache, (cfg, path) -> outcome);
+
+        TextDocumentItem item = new TextDocumentItem(modelPath.toUri().toString(), "interlis", 1, content);
+        service.didOpen(new DidOpenTextDocumentParams(item));
+
+        DocumentSymbolParams symbolParams = new DocumentSymbolParams(new TextDocumentIdentifier(item.getUri()));
+        List<Either<SymbolInformation, DocumentSymbol>> symbols = service.documentSymbol(symbolParams).get();
+
+        assertEquals(1, symbols.size());
+        Either<SymbolInformation, DocumentSymbol> modelEntry = symbols.get(0);
+        assertTrue(modelEntry.isRight());
+        DocumentSymbol modelSymbol = modelEntry.getRight();
+        assertEquals("ModelOutline", modelSymbol.getName());
+        assertEquals(SymbolKind.Module, modelSymbol.getKind());
+        assertEquals(1, modelSymbol.getChildren().size());
+
+        DocumentSymbol topicSymbol = modelSymbol.getChildren().get(0);
+        assertEquals("TopicA", topicSymbol.getName());
+        assertEquals(SymbolKind.Namespace, topicSymbol.getKind());
+        assertEquals(1, topicSymbol.getChildren().size());
+
+        DocumentSymbol classSymbol = topicSymbol.getChildren().get(0);
+        assertEquals("ClassA", classSymbol.getName());
+        assertEquals(SymbolKind.Class, classSymbol.getKind());
+        assertEquals(1, classSymbol.getChildren().size());
+
+        DocumentSymbol attributeSymbol = classSymbol.getChildren().get(0);
+        assertEquals("attr1", attributeSymbol.getName());
+        assertEquals(SymbolKind.Property, attributeSymbol.getKind());
+        assertEquals(3, attributeSymbol.getSelectionRange().getStart().getLine());
+    }
+
+    private static final class TestTable extends Table {
+        private final List<ViewableTransferElement> attributes = new ArrayList<>();
+
+        private TestTable(String name, int sourceLine) throws Exception {
+            setName(name);
+            setSourceLine(sourceLine);
+            setIdentifiable(true);
+        }
+
+        void addAttribute(AttributeDef attribute) {
+            attribute.setContainer(this);
+            attributes.add(new ViewableTransferElement(attribute));
+        }
+
+        @Override
+        public Iterator<ViewableTransferElement> getAttributesAndRoles2() {
+            return attributes.iterator();
+        }
     }
 
     private static final class ModelStub extends ch.interlis.ili2c.metamodel.Model {


### PR DESCRIPTION
## Summary
- expose hierarchical document symbols based on the compiled TransferDescription
- advertise document symbol support in the server capabilities
- cover the new outline behaviour with a unit test harnessing stubbed metamodel objects

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68dd77553dd0832880f170d02da735a8