### PR TITLE
Add completion provider for model imports and paths

### DIFF
--- a/src/main/java/ch/so/agi/lsp/interlis/ClientSettings.java
+++ b/src/main/java/ch/so/agi/lsp/interlis/ClientSettings.java
@@ -13,6 +13,9 @@ public class ClientSettings {
     /** Comma-separated string as received from the client (raw). */
     private String modelRepositories = "";
 
+    /** Whether repository discovery should silence ili2c stdout logging. */
+    private boolean suppressRepositoryLogs = true;
+
     /** Parsed, trimmed list (derived from modelRepositories). */
     public List<String> getModelRepositoriesList() {
         if (modelRepositories == null || modelRepositories.isBlank()) return List.of();
@@ -30,8 +33,16 @@ public class ClientSettings {
         this.modelRepositories = v != null ? v : "";
     }
 
+    public boolean isSuppressRepositoryLogs() {
+        return suppressRepositoryLogs;
+    }
+
+    public void setSuppressRepositoryLogs(boolean suppressRepositoryLogs) {
+        this.suppressRepositoryLogs = suppressRepositoryLogs;
+    }
+
     @Override public String toString() {
-        return "ClientSettings{modelRepositories='" + modelRepositories + "'}";
+        return "ClientSettings{modelRepositories='" + modelRepositories + "', suppressRepositoryLogs=" + suppressRepositoryLogs + "}";
     }
 
     /** Build from initOptions or didChangeConfiguration payloads. */
@@ -50,6 +61,13 @@ public class ClientSettings {
                 } else if (mr != null) {
                     s.setModelRepositories(String.valueOf(mr));
                 }
+
+                Object suppress = sec.get("suppressRepositoryLogs");
+                if (suppress instanceof Boolean bool) {
+                    s.setSuppressRepositoryLogs(bool);
+                } else if (suppress instanceof String str) {
+                    s.setSuppressRepositoryLogs(Boolean.parseBoolean(str));
+                }
             }
             return s;
         }
@@ -66,6 +84,17 @@ public class ClientSettings {
 
                 if (sec.has("modelRepositories") && sec.get("modelRepositories").isJsonPrimitive()) {
                     s.setModelRepositories(sec.getAsJsonPrimitive("modelRepositories").getAsString());
+                }
+                if (sec.has("suppressRepositoryLogs")) {
+                    JsonElement el = sec.get("suppressRepositoryLogs");
+                    if (el.isJsonPrimitive()) {
+                        JsonPrimitive prim = el.getAsJsonPrimitive();
+                        if (prim.isBoolean()) {
+                            s.setSuppressRepositoryLogs(prim.getAsBoolean());
+                        } else if (prim.isString()) {
+                            s.setSuppressRepositoryLogs(Boolean.parseBoolean(prim.getAsString()));
+                        }
+                    }
                 }
             }
         } catch (Exception ignore) { /* leave defaults */ }

--- a/src/main/java/ch/so/agi/lsp/interlis/InterlisAstUtil.java
+++ b/src/main/java/ch/so/agi/lsp/interlis/InterlisAstUtil.java
@@ -1,0 +1,225 @@
+package ch.so.agi.lsp.interlis;
+
+import ch.interlis.ili2c.metamodel.*;
+
+import java.lang.reflect.Method;
+import java.util.*;
+
+import org.eclipse.lsp4j.CompletionItemKind;
+
+/**
+ * Helpers for navigating ili2c's AST. Extracted from the jEdit plugin so it can be reused
+ * by completion/definition features in the LSP server without UI dependencies.
+ */
+final class InterlisAstUtil {
+    private InterlisAstUtil() {
+    }
+
+    static Model resolveModel(TransferDescription td, String name) {
+        if (td == null || name == null) {
+            return null;
+        }
+        String target = name.toUpperCase(Locale.ROOT);
+
+        for (Model model : td.getModelsFromLastFile()) {
+            String modelName = model != null ? model.getName() : null;
+            if (modelName != null && modelName.toUpperCase(Locale.ROOT).equals(target)) {
+                return model;
+            }
+        }
+
+        for (Model model : td.getModelsFromLastFile()) {
+            Model found = findInImportsRecursive(model, target, new HashSet<>());
+            if (found != null) {
+                return found;
+            }
+        }
+        return null;
+    }
+
+    private static Model findInImportsRecursive(Model model, String targetUpper, Set<Model> seen) {
+        if (model == null || !seen.add(model)) {
+            return null;
+        }
+        Model[] imports = model.getImporting();
+        if (imports == null) {
+            return null;
+        }
+        for (Model imp : imports) {
+            if (imp == null) {
+                continue;
+            }
+            String name = imp.getName();
+            if (name != null && name.toUpperCase(Locale.ROOT).equals(targetUpper)) {
+                return imp;
+            }
+            Model found = findInImportsRecursive(imp, targetUpper, seen);
+            if (found != null) {
+                return found;
+            }
+        }
+        return null;
+    }
+
+    static Element findChildInModelByName(Model model, String name) {
+        if (model == null || name == null) {
+            return null;
+        }
+        String target = name.toUpperCase(Locale.ROOT);
+        for (Iterator<?> it = model.iterator(); it.hasNext(); ) {
+            Object next = it.next();
+            if (!(next instanceof Element element)) {
+                continue;
+            }
+            String elementName = element.getName();
+            if (elementName != null && elementName.toUpperCase(Locale.ROOT).equals(target)) {
+                return element;
+            }
+        }
+        return null;
+    }
+
+    static Element findChildInContainerByName(Container<?> container, String name) {
+        if (container == null || name == null) {
+            return null;
+        }
+        String target = name.toUpperCase(Locale.ROOT);
+        for (Iterator<?> it = container.iterator(); it.hasNext(); ) {
+            Object next = it.next();
+            if (!(next instanceof Element element)) {
+                continue;
+            }
+            String elementName = element.getName();
+            if (elementName != null && elementName.toUpperCase(Locale.ROOT).equals(target)) {
+                return element;
+            }
+        }
+        return null;
+    }
+
+    static boolean hasAttributeOrRole(Viewable viewable, String name) {
+        if (viewable == null || name == null) {
+            return false;
+        }
+        String target = name.toUpperCase(Locale.ROOT);
+        for (Iterator<?> it = viewable.getAttributesAndRoles2(); it.hasNext(); ) {
+            ViewableTransferElement element = (ViewableTransferElement) it.next();
+            Object obj = element.obj;
+            String elementName = null;
+            if (obj instanceof AttributeDef attribute) {
+                elementName = attribute.getName();
+            } else {
+                try {
+                    Method method = obj.getClass().getMethod("getName");
+                    elementName = (String) method.invoke(obj);
+                } catch (Exception ignored) {
+                }
+            }
+            if (elementName != null && elementName.toUpperCase(Locale.ROOT).equals(target)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    static List<ChildCandidate> collectChildren(Object parent) {
+        List<ChildCandidate> result = new ArrayList<>();
+        if (parent instanceof Model model) {
+            for (Iterator<?> it = model.iterator(); it.hasNext(); ) {
+                Object next = it.next();
+                if (!(next instanceof Element element)) {
+                    continue;
+                }
+                String name = element.getName();
+                if (name == null || name.isBlank()) {
+                    continue;
+                }
+                CompletionItemKind kind = CompletionItemKind.Text;
+                if (element instanceof Topic) {
+                    kind = CompletionItemKind.Module;
+                } else if (element instanceof Viewable) {
+                    kind = CompletionItemKind.Class;
+                } else if (element instanceof Domain) {
+                    kind = CompletionItemKind.Struct;
+                } else if (element instanceof Unit) {
+                    kind = CompletionItemKind.Unit;
+                } else if (element instanceof Function) {
+                    kind = CompletionItemKind.Function;
+                }
+                result.add(new ChildCandidate(name, kind));
+            }
+        } else if (parent instanceof Topic topic) {
+            for (Iterator<?> it = topic.iterator(); it.hasNext(); ) {
+                Object next = it.next();
+                if (!(next instanceof Element element)) {
+                    continue;
+                }
+                String name = element.getName();
+                if (name == null || name.isBlank()) {
+                    continue;
+                }
+                CompletionItemKind kind = CompletionItemKind.Text;
+                if (element instanceof Viewable) {
+                    kind = CompletionItemKind.Class;
+                } else if (element instanceof Domain) {
+                    kind = CompletionItemKind.Struct;
+                } else if (element instanceof Unit) {
+                    kind = CompletionItemKind.Unit;
+                } else if (element instanceof Function) {
+                    kind = CompletionItemKind.Function;
+                }
+                result.add(new ChildCandidate(name, kind));
+            }
+        } else if (parent instanceof Viewable viewable) {
+            for (Iterator<?> it = viewable.getAttributesAndRoles2(); it.hasNext(); ) {
+                ViewableTransferElement element = (ViewableTransferElement) it.next();
+                Object obj = element.obj;
+                String name = null;
+                CompletionItemKind kind = CompletionItemKind.Field;
+                if (obj instanceof AttributeDef attribute) {
+                    name = attribute.getName();
+                } else {
+                    try {
+                        Method method = obj.getClass().getMethod("getName");
+                        name = (String) method.invoke(obj);
+                        kind = CompletionItemKind.Property;
+                    } catch (Exception ignored) {
+                    }
+                }
+                if (name != null && !name.isBlank()) {
+                    result.add(new ChildCandidate(name, kind));
+                }
+            }
+        }
+        return result;
+    }
+
+    static List<String> modelNamesForDocument(TransferDescription td) {
+        if (td == null) {
+            return Collections.emptyList();
+        }
+        LinkedHashSet<String> names = new LinkedHashSet<>();
+        for (Model model : td.getModelsFromLastFile()) {
+            if (model == null) {
+                continue;
+            }
+            String name = model.getName();
+            if (name != null) {
+                names.add(name);
+            }
+            Model[] imports = model.getImporting();
+            if (imports != null) {
+                for (Model imp : imports) {
+                    if (imp != null && imp.getName() != null) {
+                        names.add(imp.getName());
+                    }
+                }
+            }
+        }
+        return new ArrayList<>(names);
+    }
+
+    record ChildCandidate(String name, CompletionItemKind kind) {
+    }
+
+}

--- a/src/main/java/ch/so/agi/lsp/interlis/InterlisCompletionProvider.java
+++ b/src/main/java/ch/so/agi/lsp/interlis/InterlisCompletionProvider.java
@@ -1,0 +1,354 @@
+package ch.so.agi.lsp.interlis;
+
+import ch.interlis.ili2c.metamodel.Model;
+import ch.interlis.ili2c.metamodel.Topic;
+import ch.interlis.ili2c.metamodel.TransferDescription;
+import ch.interlis.ili2c.metamodel.Viewable;
+import org.eclipse.lsp4j.*;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.*;
+import java.util.function.BiFunction;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+final class InterlisCompletionProvider {
+    private static final Logger LOG = LoggerFactory.getLogger(InterlisCompletionProvider.class);
+    private static final Pattern IMPORTS_PATTERN = Pattern.compile("(?i)\\bIMPORTS\\b");
+
+    private final InterlisLanguageServer server;
+    private final DocumentTracker documents;
+    private final CompilationCache compilationCache;
+    private final BiFunction<ClientSettings, String, Ili2cUtil.CompilationOutcome> compiler;
+    private final ModelDiscoveryService modelDiscoveryService;
+
+    InterlisCompletionProvider(InterlisLanguageServer server,
+                               DocumentTracker documents,
+                               CompilationCache compilationCache,
+                               BiFunction<ClientSettings, String, Ili2cUtil.CompilationOutcome> compiler,
+                               ModelDiscoveryService discoveryService) {
+        this.server = server;
+        this.documents = documents;
+        this.compilationCache = compilationCache;
+        this.compiler = compiler != null ? compiler : Ili2cUtil::compile;
+        this.modelDiscoveryService = discoveryService;
+    }
+
+    Either<List<CompletionItem>, CompletionList> complete(CompletionParams params) {
+        try {
+            if (params == null || params.getTextDocument() == null) {
+                return Either.forLeft(Collections.emptyList());
+            }
+
+            String uri = params.getTextDocument().getUri();
+            if (uri == null || uri.isBlank()) {
+                return Either.forLeft(Collections.emptyList());
+            }
+
+            String text = documents.getText(uri);
+            if (text == null) {
+                text = InterlisTextDocumentService.readDocument(uri);
+            }
+            if (text == null) {
+                text = "";
+            }
+
+            Position position = params.getPosition();
+            int offset = DocumentTracker.toOffset(text, position);
+
+            ImportsContext importsContext = findImportsContext(text, offset);
+            if (importsContext != null) {
+                List<CompletionItem> items = buildImportCompletions(text, offset, importsContext);
+                if (!items.isEmpty()) {
+                    return Either.forLeft(items);
+                }
+            }
+
+            TransferDescription td = obtainTransferDescription(uri);
+            if (td == null) {
+                return Either.forLeft(Collections.emptyList());
+            }
+
+            int lineStart = lineStartOffset(text, offset);
+            String lineText = text.substring(lineStart, Math.min(offset, text.length()));
+
+            List<CompletionItem> dotted = completeDottedPath(text, offset, lineText, td);
+            if (!dotted.isEmpty()) {
+                return Either.forLeft(dotted);
+            }
+
+            List<CompletionItem> word = completeModelWord(text, offset, lineText, td);
+            if (!word.isEmpty()) {
+                return Either.forLeft(word);
+            }
+
+            return Either.forLeft(Collections.emptyList());
+        } catch (Exception ex) {
+            LOG.warn("Completion failed", ex);
+            return Either.forLeft(Collections.emptyList());
+        }
+    }
+
+    private List<CompletionItem> buildImportCompletions(String text, int caretOffset, ImportsContext context) {
+        ClientSettings settings = server.getClientSettings();
+        Set<String> already = new HashSet<>();
+        for (String existing : context.already()) {
+            if (existing != null) {
+                already.add(existing.toUpperCase(Locale.ROOT));
+            }
+        }
+
+        List<String> candidates = modelDiscoveryService.searchModels(settings, context.prefix(), already);
+        if (candidates.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        List<CompletionItem> items = new ArrayList<>(candidates.size());
+        Range range = new Range(DocumentTracker.positionAt(text, context.prefixStartOffset()),
+                DocumentTracker.positionAt(text, caretOffset));
+        for (String candidate : candidates) {
+            CompletionItem item = new CompletionItem(candidate);
+            item.setKind(CompletionItemKind.Module);
+            item.setTextEdit(Either.forLeft(new TextEdit(range, candidate)));
+            items.add(item);
+        }
+        return items;
+    }
+
+    private List<CompletionItem> completeDottedPath(String text, int caretOffset, String lineText, TransferDescription td) {
+        String path = trailingPath(lineText);
+        if (path.isEmpty() || !path.contains(".")) {
+            return Collections.emptyList();
+        }
+
+        String[] parts = path.split("\\.", -1);
+        if (parts.length < 2) {
+            return Collections.emptyList();
+        }
+
+        String prefix = parts[parts.length - 1];
+        Object parent = resolveChain(td, parts, parts.length - 1);
+        if (parent == null) {
+            return Collections.emptyList();
+        }
+
+        List<InterlisAstUtil.ChildCandidate> children = InterlisAstUtil.collectChildren(parent);
+        if (children.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        String upperPrefix = prefix.toUpperCase(Locale.ROOT);
+        int replaceStartOffset = Math.max(caretOffset - prefix.length(), 0);
+        Range range = new Range(DocumentTracker.positionAt(text, replaceStartOffset),
+                DocumentTracker.positionAt(text, caretOffset));
+
+        LinkedHashMap<String, CompletionItem> unique = new LinkedHashMap<>();
+        for (InterlisAstUtil.ChildCandidate child : children) {
+            String name = child.name();
+            if (name == null || name.isBlank()) {
+                continue;
+            }
+            if (!prefix.isEmpty() && !name.toUpperCase(Locale.ROOT).startsWith(upperPrefix)) {
+                continue;
+            }
+            String key = name.toUpperCase(Locale.ROOT);
+            if (unique.containsKey(key)) {
+                continue;
+            }
+            CompletionItem item = new CompletionItem(name);
+            item.setKind(child.kind());
+            item.setTextEdit(Either.forLeft(new TextEdit(range, name)));
+            unique.put(key, item);
+        }
+        return new ArrayList<>(unique.values());
+    }
+
+    private List<CompletionItem> completeModelWord(String text, int caretOffset, String lineText, TransferDescription td) {
+        String word = currentWord(lineText);
+        if (word.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        List<String> modelNames = InterlisAstUtil.modelNamesForDocument(td);
+        if (modelNames.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        String upperPrefix = word.toUpperCase(Locale.ROOT);
+        LinkedHashMap<String, CompletionItem> items = new LinkedHashMap<>();
+        Range range = new Range(DocumentTracker.positionAt(text, Math.max(caretOffset - word.length(), 0)),
+                DocumentTracker.positionAt(text, caretOffset));
+
+        for (String modelName : modelNames) {
+            if (modelName == null) {
+                continue;
+            }
+            if (!modelName.toUpperCase(Locale.ROOT).startsWith(upperPrefix)) {
+                continue;
+            }
+            String key = modelName.toUpperCase(Locale.ROOT);
+            if (items.containsKey(key)) {
+                continue;
+            }
+            CompletionItem item = new CompletionItem(modelName);
+            item.setKind(CompletionItemKind.Module);
+            item.setTextEdit(Either.forLeft(new TextEdit(range, modelName)));
+            items.put(key, item);
+        }
+
+        return new ArrayList<>(items.values());
+    }
+
+    private TransferDescription obtainTransferDescription(String uri) {
+        try {
+            String pathOrUri = InterlisTextDocumentService.toFilesystemPathIfPossible(uri);
+            if (pathOrUri == null || pathOrUri.isBlank()) {
+                return null;
+            }
+            ClientSettings settings = server.getClientSettings();
+            Ili2cUtil.CompilationOutcome outcome = compilationCache.get(pathOrUri);
+            if (outcome == null || outcome.getTransferDescription() == null) {
+                outcome = compiler.apply(settings, pathOrUri);
+                if (outcome != null) {
+                    compilationCache.put(pathOrUri, outcome);
+                }
+            }
+            return outcome != null ? outcome.getTransferDescription() : null;
+        } catch (Exception ex) {
+            LOG.warn("Failed to obtain transfer description for completion", ex);
+            return null;
+        }
+    }
+
+    private static int lineStartOffset(String text, int offset) {
+        if (text == null || text.isEmpty()) {
+            return 0;
+        }
+        int index = Math.min(Math.max(offset, 0), text.length());
+        while (index > 0) {
+            char ch = text.charAt(index - 1);
+            if (ch == '\n' || ch == '\r') {
+                break;
+            }
+            index--;
+        }
+        return index;
+    }
+
+    private static String trailingPath(String lineText) {
+        int i = lineText.length() - 1;
+        while (i >= 0) {
+            char c = lineText.charAt(i);
+            if (Character.isLetterOrDigit(c) || c == '_' || c == '.') {
+                i--;
+            } else {
+                break;
+            }
+        }
+        return lineText.substring(i + 1);
+    }
+
+    private static String currentWord(String lineText) {
+        int i = lineText.length() - 1;
+        while (i >= 0) {
+            char c = lineText.charAt(i);
+            if (Character.isLetterOrDigit(c) || c == '_') {
+                i--;
+            } else {
+                break;
+            }
+        }
+        return lineText.substring(i + 1);
+    }
+
+    private static Object resolveChain(TransferDescription td, String[] parts, int stop) {
+        if (td == null || parts == null || stop <= 0) {
+            return null;
+        }
+        Model model = InterlisAstUtil.resolveModel(td, parts[0]);
+        if (model == null) {
+            return null;
+        }
+        Object current = model;
+        for (int i = 1; i < stop; i++) {
+            String name = parts[i];
+            if (name == null || name.isEmpty()) {
+                return null;
+            }
+            if (current instanceof Model currentModel) {
+                Object child = InterlisAstUtil.findChildInModelByName(currentModel, name);
+                if (!(child instanceof Topic) && !(child instanceof Viewable)) {
+                    return null;
+                }
+                current = child;
+            } else if (current instanceof Topic topic) {
+                Object child = InterlisAstUtil.findChildInContainerByName(topic, name);
+                if (!(child instanceof Viewable)) {
+                    return null;
+                }
+                current = child;
+            } else if (current instanceof Viewable viewable) {
+                if (!InterlisAstUtil.hasAttributeOrRole(viewable, name)) {
+                    return null;
+                }
+                current = viewable;
+            } else {
+                return null;
+            }
+        }
+        return current;
+    }
+
+    private ImportsContext findImportsContext(String text, int caretOffset) {
+        if (text == null || text.isEmpty()) {
+            return null;
+        }
+        final int LOOKBACK = 2000;
+        int start = Math.max(0, caretOffset - LOOKBACK);
+        String tail = text.substring(start, caretOffset);
+
+        Matcher matcher = IMPORTS_PATTERN.matcher(tail);
+        int impStart = -1;
+        int impEnd = -1;
+        while (matcher.find()) {
+            impStart = matcher.start();
+            impEnd = matcher.end();
+        }
+        if (impStart < 0) {
+            return null;
+        }
+        if (tail.indexOf(';', impStart) >= 0) {
+            return null;
+        }
+
+        String segment = tail.substring(impEnd);
+        int lastComma = segment.lastIndexOf(',');
+        int tokenRelStart = lastComma >= 0 ? lastComma + 1 : 0;
+        int p = tokenRelStart;
+        while (p < segment.length() && Character.isWhitespace(segment.charAt(p))) {
+            p++;
+        }
+
+        int prefixStartAbs = start + impEnd + p;
+        String token = segment.substring(p);
+        String prefix = token.trim();
+
+        List<String> already = new ArrayList<>();
+        String before = segment.substring(0, p).trim();
+        if (!before.isEmpty()) {
+            String[] names = before.split(",");
+            for (String name : names) {
+                String trimmed = name.trim();
+                if (!trimmed.isEmpty()) {
+                    already.add(trimmed);
+                }
+            }
+        }
+        return new ImportsContext(prefixStartAbs, prefix, already);
+    }
+
+    private record ImportsContext(int prefixStartOffset, String prefix, List<String> already) {
+    }
+}

--- a/src/main/java/ch/so/agi/lsp/interlis/InterlisLanguageServer.java
+++ b/src/main/java/ch/so/agi/lsp/interlis/InterlisLanguageServer.java
@@ -51,6 +51,11 @@ public class InterlisLanguageServer implements LanguageServer, LanguageClientAwa
         caps.setDefinitionProvider(true);
         caps.setDocumentSymbolProvider(true);
 
+        CompletionOptions completion = new CompletionOptions();
+        completion.setResolveProvider(false);
+        completion.setTriggerCharacters(Arrays.asList(".", ":"));
+        caps.setCompletionProvider(completion);
+
         DocumentOnTypeFormattingOptions onType = new DocumentOnTypeFormattingOptions("=");
         caps.setDocumentOnTypeFormattingProvider(onType);
 

--- a/src/main/java/ch/so/agi/lsp/interlis/InterlisLanguageServer.java
+++ b/src/main/java/ch/so/agi/lsp/interlis/InterlisLanguageServer.java
@@ -30,7 +30,8 @@ public class InterlisLanguageServer implements LanguageServer, LanguageClientAwa
 
     @Override
     public CompletableFuture<InitializeResult> initialize(InitializeParams params) {
-        setClientSettings(ClientSettings.from(params.getInitializationOptions()));
+        ClientSettings settings = ClientSettings.from(params.getInitializationOptions());
+        setClientSettings(settings);
         
         ServerCapabilities caps = new ServerCapabilities();
 
@@ -110,7 +111,9 @@ public class InterlisLanguageServer implements LanguageServer, LanguageClientAwa
     }
 
     public void setClientSettings(ClientSettings s) {
-        clientSettings.set(s != null ? s : new ClientSettings());
+        ClientSettings sanitized = s != null ? s : new ClientSettings();
+        clientSettings.set(sanitized);
+        textDocumentService.onClientSettingsUpdated(sanitized);
     }
     
     public void clearOutput() {

--- a/src/main/java/ch/so/agi/lsp/interlis/InterlisTextDocumentService.java
+++ b/src/main/java/ch/so/agi/lsp/interlis/InterlisTextDocumentService.java
@@ -42,6 +42,14 @@ public class InterlisTextDocumentService implements TextDocumentService {
         this.completionProvider = new InterlisCompletionProvider(server, documents, this.compilationCache, this.compiler, this.modelDiscoveryService);
     }
 
+    void onClientSettingsUpdated(ClientSettings settings) {
+        try {
+            modelDiscoveryService.ensureInitialized(settings);
+        } catch (Exception ex) {
+            LOG.warn("Model discovery refresh failed", ex);
+        }
+    }
+
     @Override
     public void didOpen(DidOpenTextDocumentParams params) {
         String uri = params.getTextDocument().getUri();

--- a/src/main/java/ch/so/agi/lsp/interlis/InterlisTextDocumentService.java
+++ b/src/main/java/ch/so/agi/lsp/interlis/InterlisTextDocumentService.java
@@ -23,6 +23,8 @@ public class InterlisTextDocumentService implements TextDocumentService {
     private final DocumentTracker documents = new DocumentTracker();
     private final CompilationCache compilationCache;
     private final InterlisDefinitionFinder definitionFinder;
+    private final ModelDiscoveryService modelDiscoveryService;
+    private final InterlisCompletionProvider completionProvider;
     private final BiFunction<ClientSettings, String, Ili2cUtil.CompilationOutcome> compiler;
 
     public InterlisTextDocumentService(InterlisLanguageServer server) {
@@ -36,6 +38,8 @@ public class InterlisTextDocumentService implements TextDocumentService {
         this.compilationCache = cache != null ? cache : new CompilationCache();
         this.compiler = compiler != null ? compiler : Ili2cUtil::compile;
         this.definitionFinder = new InterlisDefinitionFinder(server, documents, this.compilationCache);
+        this.modelDiscoveryService = new ModelDiscoveryService();
+        this.completionProvider = new InterlisCompletionProvider(server, documents, this.compilationCache, this.compiler, this.modelDiscoveryService);
     }
 
     @Override
@@ -86,6 +90,11 @@ public class InterlisTextDocumentService implements TextDocumentService {
             LOG.error("Formatting failed", ex);
         }
         return CompletableFuture.completedFuture(edits);
+    }
+
+    @Override
+    public CompletableFuture<Either<List<CompletionItem>, CompletionList>> completion(CompletionParams params) {
+        return CompletableFuture.supplyAsync(() -> completionProvider.complete(params));
     }
 
     @Override

--- a/src/main/java/ch/so/agi/lsp/interlis/ModelDiscoveryService.java
+++ b/src/main/java/ch/so/agi/lsp/interlis/ModelDiscoveryService.java
@@ -1,6 +1,7 @@
 package ch.so.agi.lsp.interlis;
 
 import ch.ehi.basics.logging.EhiLogger;
+import ch.ehi.basics.logging.LogListener;
 import ch.ehi.basics.logging.StdListener;
 import ch.interlis.ili2c.Ili2cSettings;
 import ch.interlis.ilirepository.impl.ModelLister;
@@ -121,6 +122,8 @@ final class ModelDiscoveryService {
         }
     }
 
+    private static final LogListener NULL_LOG_LISTENER = event -> { };
+
     private static void runWithSuppressedLogs(Runnable action) {
         if (action == null) {
             return;
@@ -128,13 +131,30 @@ final class ModelDiscoveryService {
 
         synchronized (LOG_LOCK) {
             StdListener std = StdListener.getInstance();
+            var logger = EhiLogger.getInstance();
             try {
                 std.skipInfo(true);
-                EhiLogger.getInstance().removeListener(std);
+                std.skipState(true);
+                std.skipStateTrace(true);
+                std.skipUnusualStateTrace(true);
+                std.skipAdaption(true);
+                std.skipBackendCmd(true);
+                std.skipDebugTrace(true);
+
+                logger.addListener(NULL_LOG_LISTENER);
+                logger.removeListener(std);
                 action.run();
             } finally {
-                EhiLogger.getInstance().addListener(std);
+                logger.addListener(std);
+                logger.removeListener(NULL_LOG_LISTENER);
+
                 std.skipInfo(false);
+                std.skipState(false);
+                std.skipStateTrace(false);
+                std.skipUnusualStateTrace(false);
+                std.skipAdaption(false);
+                std.skipBackendCmd(false);
+                std.skipDebugTrace(false);
             }
         }
     }

--- a/src/main/java/ch/so/agi/lsp/interlis/ModelDiscoveryService.java
+++ b/src/main/java/ch/so/agi/lsp/interlis/ModelDiscoveryService.java
@@ -1,0 +1,137 @@
+package ch.so.agi.lsp.interlis;
+
+import ch.interlis.ili2c.Ili2cSettings;
+import ch.interlis.ilirepository.impl.ModelLister;
+import ch.interlis.ilirepository.impl.ModelMetadata;
+import ch.interlis.ilirepository.impl.RepositoryAccess;
+import ch.interlis.ilirepository.impl.RepositoryAccessException;
+import ch.interlis.ilirepository.impl.RepositoryVisitor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
+/**
+ * Discovers available INTERLIS models from configured repositories so completion can offer
+ * suggestions in IMPORTS clauses.
+ */
+final class ModelDiscoveryService {
+    private static final Logger LOG = LoggerFactory.getLogger(ModelDiscoveryService.class);
+
+    private final Map<String, ModelMetadata> modelCache = new ConcurrentHashMap<>();
+    private volatile boolean initialized = false;
+    private volatile String lastRepositoryKey = "";
+
+    void ensureInitialized(ClientSettings settings) {
+        String repositoryKey = buildRepositoryKey(settings);
+        if (initialized && repositoryKey.equals(lastRepositoryKey)) {
+            return;
+        }
+
+        synchronized (this) {
+            repositoryKey = buildRepositoryKey(settings);
+            if (initialized && repositoryKey.equals(lastRepositoryKey)) {
+                return;
+            }
+
+            List<String> repositories = parseRepositories(settings);
+            modelCache.clear();
+
+            for (String repository : repositories) {
+                discoverModelsFromRepository(repository);
+            }
+
+            initialized = true;
+            lastRepositoryKey = repositoryKey;
+            LOG.debug("Model discovery initialized with {} repositories ({} models)", repositories.size(), modelCache.size());
+        }
+    }
+
+    List<String> searchModels(ClientSettings settings, String prefix, Set<String> excludeUppercase) {
+        ensureInitialized(settings);
+        if (!initialized || modelCache.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        String normalized = prefix != null ? prefix.trim().toLowerCase(Locale.ROOT) : "";
+        boolean showAll = normalized.isEmpty();
+
+        List<String> result = new ArrayList<>();
+        for (String modelName : modelCache.keySet()) {
+            if (modelName == null) {
+                continue;
+            }
+            if (excludeUppercase != null && excludeUppercase.contains(modelName.toUpperCase(Locale.ROOT))) {
+                continue;
+            }
+            if (showAll || modelName.toLowerCase(Locale.ROOT).startsWith(normalized)) {
+                result.add(modelName);
+            }
+        }
+
+        result.sort(String.CASE_INSENSITIVE_ORDER);
+        return result;
+    }
+
+    private void discoverModelsFromRepository(String repositoryUrl) {
+        if (repositoryUrl == null || repositoryUrl.isBlank()) {
+            return;
+        }
+
+        RepositoryAccess repoAccess = new RepositoryAccess();
+        ModelLister modelLister = new ModelLister();
+        modelLister.setIgnoreDuplicates(true);
+
+        try {
+            RepositoryVisitor visitor = new RepositoryVisitor(repoAccess, modelLister);
+            visitor.setRepositories(new String[]{repositoryUrl});
+            visitor.visitRepositories();
+
+            List<ModelMetadata> merged = modelLister.getResult2();
+            List<ModelMetadata> latest = RepositoryAccess.getLatestVersions2(merged);
+
+            for (ModelMetadata metadata : latest) {
+                if (metadata != null && metadata.getName() != null) {
+                    modelCache.put(metadata.getName(), metadata);
+                }
+            }
+        } catch (RepositoryAccessException ex) {
+            LOG.warn("Failed to fetch repository {}: {}", repositoryUrl, ex.getMessage());
+        }
+    }
+
+    private static List<String> parseRepositories(ClientSettings settings) {
+        String repos = settings != null ? settings.getModelRepositories() : null;
+        if (repos == null || repos.isBlank()) {
+            repos = Ili2cSettings.DEFAULT_ILIDIRS;
+        }
+        String[] parts = repos.split("[;,]");
+        List<String> result = new ArrayList<>();
+        for (String part : parts) {
+            String value = part.trim();
+            if (value.isEmpty()) {
+                continue;
+            }
+            if (value.equalsIgnoreCase("%ILI_DIR") || value.equalsIgnoreCase("%JAR_DIR")) {
+                continue;
+            }
+            result.add(value);
+        }
+        if (result.isEmpty()) {
+            return Collections.emptyList();
+        }
+        return result.stream().distinct().collect(Collectors.toList());
+    }
+
+    private static String buildRepositoryKey(ClientSettings settings) {
+        List<String> repos = parseRepositories(settings);
+        return String.join(";", repos);
+    }
+}


### PR DESCRIPTION
## Summary
- add an LSP completion provider that offers suggestions for IMPORTS clauses and dotted paths
- introduce a model discovery service backed by ili repositories for model name suggestions
- add AST utilities for resolving models, topics and attributes used by completion logic

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68de3f16ee748328ac068260c89bd0f9