### PR TITLE
Handle JsonObject arguments in workspace command

### DIFF
--- a/src/main/java/ch/so/agi/lsp/interlis/InterlisWorkspaceService.java
+++ b/src/main/java/ch/so/agi/lsp/interlis/InterlisWorkspaceService.java
@@ -8,6 +8,8 @@ import org.eclipse.lsp4j.services.WorkspaceService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
 
 import java.net.URI;
@@ -85,14 +87,35 @@ public class InterlisWorkspaceService implements WorkspaceService {
         if (arg == null) return null;
         if (arg instanceof String s) return s;
         if (arg instanceof JsonPrimitive jp && jp.isString()) return jp.getAsString();
+        if (arg instanceof JsonObject jo) {
+            String uri = getStringMember(jo, "uri");
+            if (uri != null) return uri;
+            String path = getStringMember(jo, "path");
+            if (path != null) return path;
+            String title = getStringMember(jo, "title");
+            if (title != null) return title;
+        }
         if (arg instanceof java.util.Map<?, ?> map) {
             // Some clients send objects; try common shapes
             Object uri = map.get("uri");
             if (uri instanceof String s) return s;
             Object path = map.get("path");
             if (path instanceof String s) return s;
+            Object title = map.get("title");
+            if (title instanceof String s) return s;
         }
         // Fallback: last resort
         return String.valueOf(arg);
+    }
+
+    private static String getStringMember(JsonObject obj, String memberName) {
+        if (!obj.has(memberName)) return null;
+        JsonElement el = obj.get(memberName);
+        if (el == null) return null;
+        JsonPrimitive primitive = el.isJsonPrimitive() ? el.getAsJsonPrimitive() : null;
+        if (primitive != null && primitive.isString()) {
+            return primitive.getAsString();
+        }
+        return null;
     }
 }

--- a/src/test/java/ch/so/agi/lsp/interlis/InterlisWorkspaceServiceTest.java
+++ b/src/test/java/ch/so/agi/lsp/interlis/InterlisWorkspaceServiceTest.java
@@ -1,0 +1,50 @@
+package ch.so.agi.lsp.interlis;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.lsp4j.ExecuteCommandParams;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+class InterlisWorkspaceServiceTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void compileCommandAcceptsJsonObjectArgument() throws Exception {
+        Path iliFile = tempDir.resolve("SimpleModel.ili");
+        Files.writeString(iliFile, "INTERLIS 2.3;\n" +
+                "MODEL SimpleModel (en)\n" +
+                "AT \"http://example.com/SimpleModel.ili\"\n" +
+                "VERSION \"2024-01-01\" =\n" +
+                "  TOPIC SimpleTopic =\n" +
+                "    CLASS Person =\n" +
+                "    END Person;\n" +
+                "  END SimpleTopic;\n" +
+                "END SimpleModel.\n");
+
+        InterlisLanguageServer server = new InterlisLanguageServer();
+        InterlisWorkspaceService workspace = new InterlisWorkspaceService(server);
+
+        JsonObject argument = JsonParser.parseString("{\"uri\":\"" + iliFile.toUri() + "\"}").getAsJsonObject();
+
+        ExecuteCommandParams params = new ExecuteCommandParams();
+        params.setCommand(InterlisLanguageServer.CMD_COMPILE);
+        params.setArguments(List.of(argument));
+
+        CompletableFuture<Object> future = workspace.executeCommand(params);
+        Object result = future.get(30, TimeUnit.SECONDS);
+
+        assertInstanceOf(String.class, result);
+    }
+}


### PR DESCRIPTION
## Summary
- coerce workspace command arguments from Gson JsonObject members, checking uri/path/title values before falling back
- recognize title fields in map arguments for consistency
- add a workspace service test that executes the compile command with a JsonObject argument and succeeds

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68dedc537384832889eb1eaa8e24414b