### PR TITLE
Handle JSON parameters in DOCX export

### DIFF
--- a/src/test/java/ch/so/agi/lsp/interlis/InterlisWorkspaceServiceTest.java
+++ b/src/test/java/ch/so/agi/lsp/interlis/InterlisWorkspaceServiceTest.java
@@ -1,0 +1,45 @@
+package ch.so.agi.lsp.interlis;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.lang.reflect.Method;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+class InterlisWorkspaceServiceTest {
+    private static Method coerceMethod;
+
+    @BeforeAll
+    static void lookupCoerceMethod() throws Exception {
+        coerceMethod = InterlisWorkspaceService.class.getDeclaredMethod("coerceArgToString", Object.class);
+        coerceMethod.setAccessible(true);
+    }
+
+    private static String coerce(Object value) {
+        try {
+            return (String) coerceMethod.invoke(null, value);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    void coerceExtractsUriFromNestedMap() {
+        Map<String, Object> nestedUri = Map.of(
+                "scheme", "file",
+                "path", "/tmp/example.ili");
+        Map<String, Object> params = Map.of("uri", nestedUri);
+
+        assertEquals("/tmp/example.ili", coerce(params));
+    }
+
+    @Test
+    void coerceExtractsUriFromTextDocumentMap() {
+        Map<String, Object> params = Map.of(
+                "textDocument", Map.of("uri", "file:///tmp/example.ili"));
+
+        assertEquals("file:///tmp/example.ili", coerce(params));
+    }
+}

--- a/src/test/java/ch/so/agi/lsp/interlis/InterlisWorkspaceServiceTest.java
+++ b/src/test/java/ch/so/agi/lsp/interlis/InterlisWorkspaceServiceTest.java
@@ -42,4 +42,11 @@ class InterlisWorkspaceServiceTest {
 
         assertEquals("file:///tmp/example.ili", coerce(params));
     }
+
+    @Test
+    void coerceParsesJsonStringPayload() {
+        String raw = "{\"uri\":\"file:///tmp/example.ili\"}";
+
+        assertEquals("file:///tmp/example.ili", coerce(raw));
+    }
 }


### PR DESCRIPTION
## Summary
- normalize DOCX export inputs by coercing nested JSON arguments to usable paths
- cover JSON coercion behaviour with new workspace service unit tests

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68dede8939788328b3854c3c634a6cf8