### PR TITLE
Add standalone HTML documentation export

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -41,6 +41,10 @@
         "title": "INTERLIS: Show UML class diagram"
       },
       {
+        "command": "interlis.html.show",
+        "title": "INTERLIS: Show documentation as HTML"
+      },
+      {
         "command": "interlis.docx.export",
         "title": "INTERLIS: Export documentation as DOCX"
       }

--- a/src/main/java/ch/so/agi/lsp/interlis/IliDocxRenderer.java
+++ b/src/main/java/ch/so/agi/lsp/interlis/IliDocxRenderer.java
@@ -299,7 +299,7 @@ public final class IliDocxRenderer {
         return "(Class)";
     }
 
-    private static String viewableTitle(Viewable viewable) {
+    static String viewableTitle(Viewable viewable) {
         if (viewable == null) {
             return "";
         }
@@ -313,7 +313,7 @@ public final class IliDocxRenderer {
         return viewable.getName();
     }
 
-    private static String enumerationTitle(Domain domain) {
+    static String enumerationTitle(Domain domain) {
         if (domain == null) {
             return "";
         }
@@ -355,7 +355,7 @@ public final class IliDocxRenderer {
         writeAttributeTable(doc, collectRowsForViewable(model, scope, viewable));
     }
 
-    private static List<Row> collectRowsForViewable(Model model, Container scope, Viewable viewable) {
+    static List<Row> collectRowsForViewable(Model model, Container scope, Viewable viewable) {
         List<Row> rows = new ArrayList<>();
 
         for (AttributeDef attribute : getElements(viewable, AttributeDef.class)) {
@@ -465,7 +465,7 @@ public final class IliDocxRenderer {
         applyParagraphSpacing(spacer);
     }
 
-    private static List<EnumEntry> collectEnumerationEntries(EnumerationType enumType) {
+    static List<EnumEntry> collectEnumerationEntries(EnumerationType enumType) {
         List<EnumEntry> entries = new ArrayList<>();
         if (enumType == null) {
             return entries;
@@ -761,7 +761,7 @@ public final class IliDocxRenderer {
         rpr.getRFontsArray(0).setCs(FONT_FAMILY);
     }
 
-    private static <T extends Element> List<T> getElements(Container container, Class<T> type) {
+    static <T extends Element> List<T> getElements(Container container, Class<T> type) {
         List<T> out = new ArrayList<>();
         if (container == null) {
             return out;
@@ -776,7 +776,7 @@ public final class IliDocxRenderer {
         return out;
     }
 
-    private static <T extends Element> List<T> sortByName(T[] arr) {
+    static <T extends Element> List<T> sortByName(T[] arr) {
         if (arr == null) {
             return Collections.emptyList();
         }
@@ -785,7 +785,7 @@ public final class IliDocxRenderer {
         return list;
     }
 
-    private static String nz(String value) {
+    static String nz(String value) {
         return value == null ? "" : value;
     }
 
@@ -799,7 +799,7 @@ public final class IliDocxRenderer {
         spacing.setAfter(DEFAULT_SPACING_AFTER);
     }
 
-    private record EnumEntry(String value, String documentation) {}
+    static record EnumEntry(String value, String documentation) {}
 
-    private record Row(String name, String card, String type, String descr) {}
+    static record Row(String name, String card, String type, String descr) {}
 }

--- a/src/main/java/ch/so/agi/lsp/interlis/IliHtmlRenderer.java
+++ b/src/main/java/ch/so/agi/lsp/interlis/IliHtmlRenderer.java
@@ -1,0 +1,284 @@
+package ch.so.agi.lsp.interlis;
+
+import ch.interlis.ili2c.metamodel.Container;
+import ch.interlis.ili2c.metamodel.Domain;
+import ch.interlis.ili2c.metamodel.Model;
+import ch.interlis.ili2c.metamodel.Table;
+import ch.interlis.ili2c.metamodel.Topic;
+import ch.interlis.ili2c.metamodel.TransferDescription;
+import ch.interlis.ili2c.metamodel.View;
+import ch.interlis.ili2c.metamodel.Viewable;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Renders INTERLIS model metadata into a standalone HTML document.
+ */
+final class IliHtmlRenderer {
+    private static final String STYLE = """
+:root {
+  color-scheme: light dark;
+}
+body {
+  margin: 0;
+  padding: 0;
+  font-family: Arial, sans-serif;
+  background: #ffffff;
+  color: #1b1b1b;
+  line-height: 1.5;
+}
+@media (prefers-color-scheme: dark) {
+  body {
+    background: #111111;
+    color: #f5f5f5;
+  }
+  table {
+    border-color: #555555;
+    background-color: rgba(24, 24, 24, 0.95);
+  }
+  th {
+    background-color: #1e1e1e;
+  }
+  th, td {
+    border-color: #555555;
+  }
+}
+.container {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 24px 32px 48px;
+}
+.doc-title {
+  font-size: 28px;
+  font-weight: 700;
+  margin: 0 0 24px;
+}
+.heading {
+  font-size: 20px;
+  font-weight: 600;
+  margin: 24px 0 12px;
+  display: flex;
+  gap: 12px;
+  align-items: baseline;
+}
+.heading.level-2 {
+  font-size: 17px;
+}
+.heading-number {
+  font-weight: 600;
+  min-width: 60px;
+}
+.heading-text {
+  flex: 1 1 auto;
+}
+.metadata {
+  margin: 4px 0;
+  font-weight: 500;
+}
+.documentation {
+  margin: 8px 0 16px;
+}
+table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 0 0 24px;
+  border: 1px solid #999999;
+  background: rgba(255, 255, 255, 0.96);
+}
+th, td {
+  border: 1px solid #999999;
+  padding: 6px 10px;
+  text-align: left;
+  vertical-align: top;
+  font-size: 14px;
+}
+th {
+  font-weight: 600;
+  background-color: #f1f1f1;
+}
+.annotation {
+  color: #6b6b6b;
+  font-size: 13px;
+}
+""";
+
+    private IliHtmlRenderer() {}
+
+    static String render(TransferDescription td, String documentTitle) {
+        Objects.requireNonNull(td, "TransferDescription is null");
+
+        String titleText = (documentTitle == null || documentTitle.isBlank()) ? "INTERLIS" : documentTitle;
+
+        StringBuilder sb = new StringBuilder(8192);
+        sb.append("<!DOCTYPE html>\n");
+        sb.append("<html lang=\"de\">\n<head>\n<meta charset=\"utf-8\"/>\n");
+        sb.append("<title>").append(escape(titleText)).append("</title>\n");
+        sb.append("<style>").append(STYLE).append("</style>\n");
+        sb.append("</head>\n<body>\n<div class=\"container\">\n");
+
+        if (documentTitle != null && !documentTitle.isBlank()) {
+            sb.append("<h1 class=\"doc-title\">").append(escape(documentTitle)).append("</h1>\n");
+        }
+
+        Numbering numbering = new Numbering();
+        Model[] models = td.getModelsFromLastFile();
+        if (models != null) {
+            for (Model model : IliDocxRenderer.sortByName(models)) {
+                appendHeading(sb, numbering, 0, model.getName());
+                appendModelMetadata(sb, model);
+
+                renderViewables(sb, numbering, model, model, 1);
+                renderEnumerations(sb, numbering, model, model, 1);
+
+                for (Topic topic : IliDocxRenderer.getElements(model, Topic.class)) {
+                    appendHeading(sb, numbering, 0, topic.getName());
+                    appendDocumentation(sb, topic.getDocumentation());
+                    renderViewables(sb, numbering, model, topic, 1);
+                    renderEnumerations(sb, numbering, model, topic, 1);
+                }
+            }
+        }
+
+        sb.append("</div>\n</body>\n</html>\n");
+        return sb.toString();
+    }
+
+    private static void renderViewables(StringBuilder sb, Numbering numbering, Model model, Container scope, int headingLevel) {
+        for (Table table : IliDocxRenderer.getElements(scope, Table.class)) {
+            writeViewableSection(sb, numbering, model, scope, table, headingLevel);
+        }
+
+        for (Viewable viewable : IliDocxRenderer.getElements(scope, Viewable.class)) {
+            if (viewable instanceof Table) {
+                continue;
+            }
+            if (viewable instanceof View) {
+                writeViewableSection(sb, numbering, model, scope, viewable, headingLevel);
+            }
+        }
+    }
+
+    private static void renderEnumerations(StringBuilder sb, Numbering numbering, Model model, Container scope, int headingLevel) {
+        for (Domain domain : IliDocxRenderer.getElements(scope, Domain.class)) {
+            if (!(domain.getType() instanceof ch.interlis.ili2c.metamodel.EnumerationType enumType)) {
+                continue;
+            }
+            appendHeading(sb, numbering, headingLevel, IliDocxRenderer.enumerationTitle(domain));
+            appendDocumentation(sb, domain.getDocumentation());
+            appendEnumerationTable(sb, IliDocxRenderer.collectEnumerationEntries(enumType));
+        }
+    }
+
+    private static void writeViewableSection(StringBuilder sb, Numbering numbering, Model model, Container scope,
+            Viewable viewable, int headingLevel) {
+        appendHeading(sb, numbering, headingLevel, IliDocxRenderer.viewableTitle(viewable));
+        appendDocumentation(sb, viewable.getDocumentation());
+        appendAttributeTable(sb, IliDocxRenderer.collectRowsForViewable(model, scope, viewable));
+    }
+
+    private static void appendModelMetadata(StringBuilder sb, Model model) {
+        if (model == null) {
+            return;
+        }
+        String title = IliDocxRenderer.nz(model.getMetaValue("title"));
+        if (!title.isBlank()) {
+            sb.append("<p class=\"metadata\"><strong>Titel:</strong> ").append(escape(title)).append("</p>\n");
+        }
+        String shortDescr = IliDocxRenderer.nz(model.getMetaValue("shortDescription"));
+        if (!shortDescr.isBlank()) {
+            sb.append("<p class=\"metadata\"><strong>Beschreibung:</strong> ")
+                    .append(escape(shortDescr)).append("</p>\n");
+        }
+    }
+
+    private static void appendDocumentation(StringBuilder sb, String documentation) {
+        if (documentation == null || documentation.trim().isEmpty()) {
+            return;
+        }
+        sb.append("<p class=\"documentation\">");
+        String[] lines = documentation.split("\\r?\\n");
+        for (int i = 0; i < lines.length; i++) {
+            sb.append(escape(lines[i]));
+            if (i < lines.length - 1) {
+                sb.append("<br/>");
+            }
+        }
+        sb.append("</p>\n");
+    }
+
+    private static void appendAttributeTable(StringBuilder sb, List<IliDocxRenderer.Row> rows) {
+        sb.append("<table class=\"attributes\">\n");
+        sb.append("<colgroup><col style=\"width:25%\"/><col style=\"width:17%\"/><col style=\"width:25%\"/><col style=\"width:33%\"/></colgroup>\n");
+        sb.append("<thead><tr><th>Attributname</th><th>Kardinalität</th><th>Typ</th><th>Beschreibung</th></tr></thead>\n<tbody>\n");
+        if (rows != null) {
+            for (IliDocxRenderer.Row row : rows) {
+                sb.append("<tr><td>").append(escape(IliDocxRenderer.nz(row.name()))).append("</td>");
+                sb.append("<td>").append(escape(IliDocxRenderer.nz(row.card()))).append("</td>");
+                sb.append("<td>").append(escape(IliDocxRenderer.nz(row.type()))).append("</td>");
+                sb.append("<td>").append(escape(IliDocxRenderer.nz(row.descr()))).append("</td></tr>\n");
+            }
+        }
+        sb.append("</tbody>\n</table>\n");
+    }
+
+    private static void appendEnumerationTable(StringBuilder sb, List<IliDocxRenderer.EnumEntry> entries) {
+        sb.append("<table class=\"enumeration\">\n");
+        sb.append("<colgroup><col style=\"width:35%\"/><col style=\"width:65%\"/></colgroup>\n");
+        sb.append("<thead><tr><th>Wert</th><th>Beschreibung</th></tr></thead>\n<tbody>\n");
+        for (IliDocxRenderer.EnumEntry entry : entries) {
+            sb.append("<tr><td>").append(escape(IliDocxRenderer.nz(entry.value()))).append("</td>");
+            sb.append("<td>").append(escape(IliDocxRenderer.nz(entry.documentation()))).append("</td></tr>\n");
+        }
+        sb.append("</tbody>\n</table>\n");
+    }
+
+    private static void appendHeading(StringBuilder sb, Numbering numbering, int headingLevel, String text) {
+        String headingText = text != null ? text : "";
+        String number = numbering.next(headingLevel);
+        String tag = headingLevel <= 0 ? "h2" : "h3";
+        sb.append('<').append(tag).append(" class=\"heading level-")
+                .append(headingLevel <= 0 ? "1" : "2").append("\">");
+        if (!number.isEmpty()) {
+            sb.append("<span class=\"heading-number\">").append(escape(number)).append("</span>");
+        }
+        sb.append("<span class=\"heading-text\">").append(escape(headingText)).append("</span>");
+        sb.append("</").append(tag).append(">\n");
+    }
+
+    private static String escape(String text) {
+        if (text == null || text.isEmpty()) {
+            return "";
+        }
+        StringBuilder escaped = new StringBuilder(text.length() + 16);
+        for (int i = 0; i < text.length(); i++) {
+            char ch = text.charAt(i);
+            switch (ch) {
+                case '&' -> escaped.append("&amp;");
+                case '<' -> escaped.append("&lt;");
+                case '>' -> escaped.append("&gt;");
+                case '"' -> escaped.append("&quot;");
+                case '\'' -> escaped.append("&#39;");
+                default -> escaped.append(ch);
+            }
+        }
+        return escaped.toString();
+    }
+
+    private static final class Numbering {
+        private int level0 = 0;
+        private int level1 = 0;
+
+        String next(int headingLevel) {
+            if (headingLevel <= 0) {
+                level0++;
+                level1 = 0;
+                return Integer.toString(level0);
+            }
+            if (level0 <= 0) {
+                level0 = 1;
+            }
+            level1++;
+            return level0 + "." + level1;
+        }
+    }
+}

--- a/src/main/java/ch/so/agi/lsp/interlis/InterlisHtmlExporter.java
+++ b/src/main/java/ch/so/agi/lsp/interlis/InterlisHtmlExporter.java
@@ -1,0 +1,16 @@
+package ch.so.agi.lsp.interlis;
+
+import ch.interlis.ili2c.metamodel.TransferDescription;
+import java.util.Objects;
+
+/**
+ * Utility for producing HTML documents containing an INTERLIS model summary.
+ */
+public final class InterlisHtmlExporter {
+    private InterlisHtmlExporter() {}
+
+    public static String renderHtml(TransferDescription td, String title) {
+        Objects.requireNonNull(td, "TransferDescription must not be null");
+        return IliHtmlRenderer.render(td, title);
+    }
+}

--- a/src/main/java/ch/so/agi/lsp/interlis/InterlisLanguageServer.java
+++ b/src/main/java/ch/so/agi/lsp/interlis/InterlisLanguageServer.java
@@ -21,6 +21,7 @@ public class InterlisLanguageServer implements LanguageServer, LanguageClientAwa
     public static final String CMD_COMPILE = "interlis.compile"; // workspace/executeCommand
     public static final String CMD_GENERATE_UML = "interlis.uml";
     public static final String REQ_EXPORT_DOCX = "interlis/exportDocx";
+    public static final String REQ_EXPORT_HTML = "interlis/exportHtml";
 
     public InterlisLanguageServer() {
         this.textDocumentService = new InterlisTextDocumentService(this);

--- a/src/main/java/ch/so/agi/lsp/interlis/InterlisWorkspaceService.java
+++ b/src/main/java/ch/so/agi/lsp/interlis/InterlisWorkspaceService.java
@@ -72,7 +72,7 @@ public class InterlisWorkspaceService implements WorkspaceService {
 
     @JsonRequest(InterlisLanguageServer.REQ_EXPORT_DOCX)
     public CompletableFuture<String> exportDocx(Object rawParams) {
-        ExportDocxParams params = coerceExportParams(rawParams);
+        DocumentExportParams params = coerceExportParams(rawParams);
         if (params == null) {
             return invalidParams("Expected parameters with uri or path");
         }
@@ -87,18 +87,35 @@ public class InterlisWorkspaceService implements WorkspaceService {
         return handlers.exportDocx(normalized, params.getTitle());
     }
 
-    private ExportDocxParams coerceExportParams(Object rawParams) {
+    @JsonRequest(InterlisLanguageServer.REQ_EXPORT_HTML)
+    public CompletableFuture<String> exportHtml(Object rawParams) {
+        DocumentExportParams params = coerceExportParams(rawParams);
+        if (params == null) {
+            return invalidParams("Expected parameters with uri or path");
+        }
+
+        String candidate = firstNonBlank(params.getPath(), params.getUri());
+        String normalized = normalizePath(candidate);
+        if (normalized == null) {
+            return invalidParams("Expected uri or path to be provided");
+        }
+
+        LOG.info("html export called with: {}", normalized);
+        return handlers.exportHtml(normalized, params.getTitle());
+    }
+
+    private DocumentExportParams coerceExportParams(Object rawParams) {
         if (rawParams == null) {
             return null;
         }
 
         Object normalized = decodePotentialJson(rawParams);
 
-        if (normalized instanceof ExportDocxParams typed) {
+        if (normalized instanceof DocumentExportParams typed) {
             return typed;
         }
 
-        ExportDocxParams params = new ExportDocxParams();
+        DocumentExportParams params = new DocumentExportParams();
 
         if (normalized instanceof java.util.Map<?, ?> map) {
             params.setUri(coerceArgToString(map.get("uri")));
@@ -371,12 +388,12 @@ public class InterlisWorkspaceService implements WorkspaceService {
         return null;
     }
 
-    public static class ExportDocxParams {
+    public static class DocumentExportParams {
         private String uri;
         private String path;
         private String title;
 
-        public ExportDocxParams() {}
+        public DocumentExportParams() {}
 
         public String getUri() {
             return uri;

--- a/src/test/java/ch/so/agi/lsp/interlis/CommandHandlersTest.java
+++ b/src/test/java/ch/so/agi/lsp/interlis/CommandHandlersTest.java
@@ -63,4 +63,19 @@ class CommandHandlersTest {
         assertEquals(ResponseErrorCode.InternalError.getValue(), ree.getResponseError().getCode());
         assertTrue(ree.getMessage().contains(nonexistent.getFileName().toString()));
     }
+
+    @Test
+    void exportHtmlFailsWithResponseErrorWhenCompilationFails() {
+        InterlisLanguageServer server = new InterlisLanguageServer();
+        CommandHandlers handlers = new CommandHandlers(server);
+
+        Path nonexistent = tempDir.resolve("MissingHtml.ili");
+        CompletableFuture<String> future = handlers.exportHtml(nonexistent.toUri().toString(), null);
+
+        ExecutionException exec = assertThrows(ExecutionException.class, () -> future.get(30, TimeUnit.SECONDS));
+        Throwable cause = exec.getCause();
+        ResponseErrorException ree = assertInstanceOf(ResponseErrorException.class, cause);
+        assertEquals(ResponseErrorCode.InternalError.getValue(), ree.getResponseError().getCode());
+        assertTrue(ree.getMessage().contains(nonexistent.getFileName().toString()));
+    }
 }

--- a/src/test/java/ch/so/agi/lsp/interlis/InterlisHtmlExporterTest.java
+++ b/src/test/java/ch/so/agi/lsp/interlis/InterlisHtmlExporterTest.java
@@ -1,0 +1,173 @@
+package ch.so.agi.lsp.interlis;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ch.interlis.ili2c.metamodel.AttributeDef;
+import ch.interlis.ili2c.metamodel.Domain;
+import ch.interlis.ili2c.metamodel.Enumeration;
+import ch.interlis.ili2c.metamodel.EnumerationType;
+import ch.interlis.ili2c.metamodel.Model;
+import ch.interlis.ili2c.metamodel.Table;
+import ch.interlis.ili2c.metamodel.Topic;
+import ch.interlis.ili2c.metamodel.TransferDescription;
+import ch.interlis.ili2c.metamodel.View;
+import ch.interlis.ili2c.metamodel.Viewable;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Iterator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class InterlisHtmlExporterTest {
+
+    @Test
+    void createsStandaloneHtmlWithModelContent(@TempDir Path tempDir) throws Exception {
+        Path iliFile = Files.createTempFile(tempDir, "DocTest", ".ili");
+        Files.writeString(iliFile, String.join("\n",
+                "INTERLIS 2.3;",
+                "MODEL DocTest (en)",
+                "!!@ title=\"Model Title\"",
+                "!!@ shortDescription=\"Model short description\"",
+                "AT \"http://example.com/DocTest.ili\"",
+                "VERSION \"2024-01-01\" =",
+                "  TOPIC DocTopic =",
+                "    DOMAIN RoofColor = (rot (hell, dunkel), blau);",
+                "    STRUCTURE Address =",
+                "      Street : MANDATORY TEXT*50;",
+                "    END Address;",
+                "    CLASS Building =",
+                "      Name : MANDATORY TEXT*50;",
+                "      Address : Address;",
+                "      RoofColor : RoofColor;",
+                "      Status : (geplant, gebaut, abgerissen);",
+                "    END Building;",
+                "  END DocTopic;",
+                "END DocTest.",
+                ""));
+
+        Ili2cUtil.CompilationOutcome outcome = Ili2cUtil.compile(new ClientSettings(), iliFile.toString());
+        TransferDescription td = outcome.getTransferDescription();
+        assertNotNull(td, "Expected compile to produce transfer description");
+
+        Model[] models = td.getModelsFromLastFile();
+        assertNotNull(models);
+        Model model = models[0];
+        model.setMetaValue("title", "Model Title");
+        model.setMetaValue("shortDescription", "Model short description");
+
+        Topic topic = findTopic(model, "DocTopic");
+        topic.setDocumentation("Topic documentation");
+
+        Table structure = findTable(topic, "Address");
+        structure.setDocumentation("Structure documentation");
+        try {
+            structure.setAbstract(true);
+        } catch (java.beans.PropertyVetoException e) {
+            throw new IllegalStateException("Unable to mark structure abstract", e);
+        }
+
+        Table clazz = findTable(topic, "Building");
+        clazz.setDocumentation("Class documentation");
+
+        AttributeDef statusAttribute = findAttribute(clazz, "Status");
+        EnumerationType inlineEnum = (EnumerationType) statusAttribute.getDomain();
+        inlineEnum.getEnumeration().getElement(0).setDocumentation("Geplant doc");
+
+        Domain enumDomain = findDomain(topic, "RoofColor");
+        enumDomain.setDocumentation("Roof color documentation");
+        EnumerationType enumerationType = (EnumerationType) enumDomain.getType();
+        Enumeration enumeration = enumerationType.getEnumeration();
+        Enumeration.Element rot = enumeration.getElement(0);
+        rot.setDocumentation("Rot doc");
+        Enumeration subRot = rot.getSubEnumeration();
+        subRot.getElement(0).setDocumentation("Hell doc");
+        subRot.getElement(1).setDocumentation("Dunkel doc");
+        enumeration.getElement(1).setDocumentation("Blau doc");
+
+        Viewable view = addSyntheticView(topic, "BuildingView");
+        view.setDocumentation("View documentation");
+
+        String html = InterlisHtmlExporter.renderHtml(td, "Document Title");
+        assertNotNull(html);
+        assertTrue(html.contains("<!DOCTYPE html>"));
+        assertTrue(html.contains("<title>Document Title</title>"));
+        assertTrue(html.contains("<h1 class=\"doc-title\">Document Title</h1>"));
+
+        assertTrue(html.contains("<span class=\"heading-number\">1</span><span class=\"heading-text\">DocTest</span>"));
+        assertTrue(html.contains("<p class=\"metadata\"><strong>Titel:</strong> Model Title</p>"));
+        assertTrue(html.contains("<span class=\"heading-number\">2</span><span class=\"heading-text\">DocTopic</span>"));
+        assertTrue(html.contains("<span class=\"heading-number\">2.1</span><span class=\"heading-text\">Address (Abstract Structure)</span>"));
+        assertTrue(html.contains("<span class=\"heading-number\">2.2</span><span class=\"heading-text\">Building (Class)</span>"));
+        assertTrue(html.contains("<span class=\"heading-number\">2.3</span><span class=\"heading-text\">BuildingView (View)</span>"));
+        assertTrue(html.contains("<span class=\"heading-number\">2.4</span><span class=\"heading-text\">RoofColor (Enumeration)</span>"));
+        assertTrue(html.contains("Topic documentation"));
+        assertTrue(html.contains("Structure documentation"));
+        assertTrue(html.contains("Class documentation"));
+        assertTrue(html.contains("View documentation"));
+        assertTrue(html.contains("Roof color documentation"));
+
+        assertTrue(html.contains("<th>Attributname</th><th>Kardinalität</th><th>Typ</th><th>Beschreibung</th>"));
+        assertTrue(html.contains("<td>Status</td><td>0..1</td><td>Enumeration</td><td>geplant, gebaut, abgerissen</td>"));
+
+        assertTrue(html.contains("<th>Wert</th><th>Beschreibung</th>"));
+        assertTrue(html.contains("<td>rot.hell</td><td>Hell doc</td>"));
+        assertTrue(html.contains("<td>rot.dunkel</td><td>Dunkel doc</td>"));
+        assertTrue(html.contains("<td>blau</td><td>Blau doc</td>"));
+
+        assertFalse(html.contains("<script"));
+        assertFalse(html.contains("<link"));
+    }
+
+    private static Topic findTopic(Model model, String name) {
+        for (Iterator<?> it = model.iterator(); it.hasNext();) {
+            Object next = it.next();
+            if (next instanceof Topic topic && name.equals(topic.getName())) {
+                return topic;
+            }
+        }
+        throw new IllegalStateException("Topic not found: " + name);
+    }
+
+    private static Table findTable(Topic topic, String name) {
+        for (Iterator<?> it = topic.iterator(); it.hasNext();) {
+            Object next = it.next();
+            if (next instanceof Table table && name.equals(table.getName())) {
+                return table;
+            }
+        }
+        throw new IllegalStateException("Table not found: " + name);
+    }
+
+    private static Domain findDomain(Topic topic, String name) {
+        for (Iterator<?> it = topic.iterator(); it.hasNext();) {
+            Object next = it.next();
+            if (next instanceof Domain domain && name.equals(domain.getName())) {
+                return domain;
+            }
+        }
+        throw new IllegalStateException("Domain not found: " + name);
+    }
+
+    private static AttributeDef findAttribute(Table table, String name) {
+        for (Iterator<?> it = table.iterator(); it.hasNext();) {
+            Object next = it.next();
+            if (next instanceof AttributeDef attribute && name.equals(attribute.getName())) {
+                return attribute;
+            }
+        }
+        throw new IllegalStateException("Attribute not found: " + name);
+    }
+
+    private static Viewable addSyntheticView(Topic topic, String name) {
+        View view = new View() {};
+        try {
+            view.setName(name);
+        } catch (java.beans.PropertyVetoException e) {
+            throw new IllegalStateException("Unable to name synthetic view", e);
+        }
+        topic.add(view);
+        return view;
+    }
+}


### PR DESCRIPTION
## Summary
- add an HTML renderer/exporter that reuses the DOCX rendering helpers to build a self-contained documentation page
- extend the language server with an interlis/exportHtml request and expose it through the VS Code client
- add tests covering the HTML exporter and error handling for the new request

## Testing
- `./gradlew test`
- `npm --prefix client run build`


------
https://chatgpt.com/codex/tasks/task_e_68dfa09c6ac48328a2d9bd0ec257a0c7