### PR TITLE
Ensure packaged runtimes retain execute permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -266,6 +266,9 @@ jobs:
             mkdir -p "$dest_dir"
             rm -rf "${dest_dir:?}/"*
             cp -a "$src_dir"/. "$dest_dir"/
+            if [[ "$dest" != win32-* && -d "$dest_dir/bin" ]]; then
+              find "$dest_dir/bin" -type f -exec chmod +x {} +
+            fi
             echo "Staged runtime for $src -> $dest"
           done
 


### PR DESCRIPTION
## Summary
- ensure the staged Unix runtimes have their bin files marked executable before packaging the VS Code extension

## Testing
- not run (not needed)


------
https://chatgpt.com/codex/tasks/task_e_68e151d4f5708328bce279638c53fcd0