### PR TITLE
Bundle VS Code language client with extension build

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,12 +1,13 @@
 {
-  "name": "interlis-lsp-client",
-  "version": "0.0.1",
+  "name": "interlis-editor",
+  "version": "0.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "interlis-lsp-client",
-      "version": "0.0.1",
+      "name": "interlis-editor",
+      "version": "0.0.2",
+      "license": "MIT",
       "dependencies": {
         "vscode-languageclient": "^9.0.1"
       },

--- a/client/package.json
+++ b/client/package.json
@@ -118,8 +118,8 @@
   },
   "main": "./dist/extension.js",
   "scripts": {
-    "build": "esbuild src/extension.ts --bundle --platform=node --external:vscode --external:vscode-languageclient --external:vscode-languageclient/node --outfile=dist/extension.js",
-    "watch": "esbuild src/extension.ts --bundle --platform=node --external:vscode --external:vscode-languageclient --external:vscode-languageclient/node --outfile=dist/extension.js --watch"
+    "build": "esbuild src/extension.ts --bundle --platform=node --external:vscode --outfile=dist/extension.js",
+    "watch": "esbuild src/extension.ts --bundle --platform=node --external:vscode --outfile=dist/extension.js --watch"
   },
   "devDependencies": {
     "@types/node": "^24.5.2",


### PR DESCRIPTION
## Summary
- stop marking `vscode-languageclient` as external in the client build so the dependency is bundled with the extension
- refresh the npm lockfile metadata after rebuilding the extension

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e15bc3bc2083289693987b3e21de07