### PR TITLE
Restrict VS Code extension publishing to trusted triggers

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -317,7 +317,7 @@ jobs:
           if-no-files-found: error
 
       - name: Publish VS Code extension
-        if: ${{ env.VS_MARKETPLACE_TOKEN != '' }}
+        if: ${{ (github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main')) && env.VS_MARKETPLACE_TOKEN != '' }}
         env:
           VSCE_PAT: ${{ secrets.VS_MARKETPLACE_TOKEN }}
         working-directory: client


### PR DESCRIPTION
## Summary
- ensure the VS Code marketplace publishing step only runs for pushes to main or manual dispatches
- keep publishing gated on the presence of the marketplace token

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e15e302f5483289de8c634adcfbc2a