### PR TITLE
Improve syntax highlighting for INTERLIS meta attribute comments

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -109,7 +109,7 @@
       "editor.tokenColorCustomizations": {
         "textMateRules": [
           {
-            "scope": "source.interlis comment.line.meta-attribute.interlis",
+            "scope": "entity.name.tag.meta-attribute.interlis",
             "settings": { "foreground": "#d19a66", "fontStyle": "" }
           }
         ]

--- a/client/syntaxes/interlis.tmLanguage.json
+++ b/client/syntaxes/interlis.tmLanguage.json
@@ -40,7 +40,18 @@
       "patterns": [
         {
           "name": "comment.line.meta-attribute.interlis",
-          "match": "^\\s*!!@.*\\r?$"
+          "match": "^(\\s*!!@)(.*?)(\\r?)$",
+          "captures": {
+            "1": {
+              "name": "punctuation.definition.comment.interlis"
+            },
+            "2": {
+              "name": "entity.name.tag.meta-attribute.interlis"
+            },
+            "3": {
+              "name": "punctuation.definition.comment.interlis"
+            }
+          }
         },
         {
           "name": "comment.line.double-exclamation.ili",


### PR DESCRIPTION
## Summary
- refine the TextMate grammar so meta-attribute comments expose a dedicated scope for their body
- retarget the default token color customization to the new scope for consistent highlighting in packaged builds

## Testing
- `npm --prefix client run build`


------
https://chatgpt.com/codex/tasks/task_e_68e172902eb88328819aa42e95f26ad3