### PR TITLE
Open INTERLIS output channel when log notifications arrive

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -146,6 +146,11 @@ export async function activate(context: vscode.ExtensionContext) {
 
   // Register notification handlers ONCE, immediately
   let handlersRegistered = false;
+  const revealOutputChannel = (preserveEditorFocus = true) => {
+    output.show(preserveEditorFocus);
+    void ensurePanelVisible(preserveEditorFocus);
+  };
+
   const registerHandlersOnce = () => {
     if (handlersRegistered) return;
     handlersRegistered = true;
@@ -153,7 +158,7 @@ export async function activate(context: vscode.ExtensionContext) {
     client!.onNotification("interlis/clearLog", () => {
       output.clear();
       if (revealOutputOnNextLog) {
-        output.show(true);
+        revealOutputChannel(true);
         revealOutputOnNextLog = false;
       }
     });
@@ -161,7 +166,7 @@ export async function activate(context: vscode.ExtensionContext) {
     client!.onNotification("interlis/log", (p: { text?: string }) => {
       if (p?.text) {
         output.append(p.text);
-        ensurePanelVisible();
+        revealOutputChannel(true);
       }
     });
   };


### PR DESCRIPTION
## Summary
- ensure the INTERLIS output channel is shown whenever log notifications append text
- reuse the same helper when manual compile requests trigger log clearing

## Testing
- npm --prefix client run build

------
https://chatgpt.com/codex/tasks/task_e_68ed60622a9c8328bb0bb83ed740047b