### PR TITLE
Explain why didChange invalidates the compilation cache

### DIFF
--- a/src/main/java/ch/so/agi/lsp/interlis/InterlisTextDocumentService.java
+++ b/src/main/java/ch/so/agi/lsp/interlis/InterlisTextDocumentService.java
@@ -65,6 +65,12 @@ public class InterlisTextDocumentService implements TextDocumentService {
         documents.applyChanges(params.getTextDocument(), params.getContentChanges());
         String uri = params.getTextDocument().getUri();
         String pathOrUri = toFilesystemPathIfPossible(uri);
+        // Any edit invalidates the transfer description cached for this document. Features
+        // such as completion, rename or document symbols combine the live text tracked by
+        // {@link DocumentTracker} with the cached {@link Ili2cUtil.CompilationOutcome}.
+        // Keeping the old compilation result after a change would leave those features with
+        // stale model information until the file is saved, so we drop the cache entry here
+        // and let the next request trigger a fresh compile if it needs one.
         compilationCache.invalidate(pathOrUri);
     }
 


### PR DESCRIPTION
## Summary
- document why `didChange` clears the cached compilation outcome so LSP features recompile against the latest edits

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68f14c61de50832889d4ef65e11c5ce0