### PR TITLE
Add GLSP server skeleton for INTERLIS diagrams

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,9 @@ dependencies {
     implementation 'org.eclipse.lsp4j:org.eclipse.lsp4j:0.24.0'
     implementation 'org.eclipse.lsp4j:org.eclipse.lsp4j.jsonrpc:0.24.0'
 
+    implementation 'org.eclipse.glsp:org.eclipse.glsp.server:2.5.0'
+    implementation 'org.eclipse.glsp:org.eclipse.glsp.server.websocket:2.5.0'
+
     implementation 'ch.interlis:ili2c-tool:5.6.6'
     implementation 'ch.interlis:ili2c-core:5.6.6'
     implementation 'ch.ehi:ehibasics:1.4.1'

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "interlis-editor",
-  "version": "0.0.12",
+  "version": "0.0.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "interlis-editor",
-      "version": "0.0.12",
+      "version": "0.0.18",
       "license": "MIT",
       "dependencies": {
+        "@eclipse-glsp/vscode-integration": "^2.5.0",
         "vscode-languageclient": "^9.0.1"
       },
       "devDependencies": {
@@ -19,6 +20,35 @@
       },
       "engines": {
         "vscode": "^1.90.0"
+      }
+    },
+    "node_modules/@eclipse-glsp/protocol": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@eclipse-glsp/protocol/-/protocol-2.5.0.tgz",
+      "integrity": "sha512-bPHGamXtkbhFqV+2LAzrkOWw7iUmFIdYT+5uPdGqo3BPITiAA2cyE3iRuePwqgiqidhZrhPW60vL0GRgvgZ3TQ==",
+      "license": "(EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0)",
+      "dependencies": {
+        "sprotty-protocol": "1.4.0",
+        "uuid": "~10.0.0",
+        "vscode-jsonrpc": "8.2.0"
+      },
+      "peerDependencies": {
+        "inversify": "^6.1.3"
+      }
+    },
+    "node_modules/@eclipse-glsp/vscode-integration": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@eclipse-glsp/vscode-integration/-/vscode-integration-2.5.0.tgz",
+      "integrity": "sha512-XwsRe1u0xgs8UWDztg1/6NhhNoP2diRsN+nD+g0HHiJld46excNK76S3dhfJmbhniFSVXq0/mLpshu+I4NKyWA==",
+      "license": "(EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0)",
+      "dependencies": {
+        "@eclipse-glsp/protocol": "2.5.0",
+        "vscode-jsonrpc": "8.2.0",
+        "vscode-messenger": "^0.4.5",
+        "ws": "^8.13.0"
+      },
+      "engines": {
+        "vscode": "^1.54.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -463,6 +493,34 @@
         "node": ">=18"
       }
     },
+    "node_modules/@inversifyjs/common": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@inversifyjs/common/-/common-1.4.0.tgz",
+      "integrity": "sha512-qfRJ/3iOlCL/VfJq8+4o5X4oA14cZSBbpAmHsYj8EsIit1xDndoOl0xKOyglKtQD4u4gdNVxMHx4RWARk/I4QA==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@inversifyjs/core": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@inversifyjs/core/-/core-1.3.5.tgz",
+      "integrity": "sha512-B4MFXabhNTAmrfgB+yeD6wd/GIvmvWC6IQ8Rh/j2C3Ix69kmqwz9pr8Jt3E+Nho9aEHOQCZaGmrALgtqRd+oEQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@inversifyjs/common": "1.4.0",
+        "@inversifyjs/reflect-metadata-utils": "0.2.4"
+      }
+    },
+    "node_modules/@inversifyjs/reflect-metadata-utils": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@inversifyjs/reflect-metadata-utils/-/reflect-metadata-utils-0.2.4.tgz",
+      "integrity": "sha512-u95rV3lKfG+NT2Uy/5vNzoDujos8vN8O18SSA5UyhxsGYd4GLQn/eUsGXfOsfa7m34eKrDelTKRUX1m/BcNX5w==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "reflect-metadata": "0.2.2"
+      }
+    },
     "node_modules/@types/node": {
       "version": "24.7.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.7.2.tgz",
@@ -537,6 +595,20 @@
         "@esbuild/win32-x64": "0.25.10"
       }
     },
+    "node_modules/inversify": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/inversify/-/inversify-6.2.2.tgz",
+      "integrity": "sha512-KB836KHbZ9WrUnB8ax5MtadOwnqQYa+ZJO3KWbPFgcr4RIEnHM621VaqFZzOZd9+U7ln6upt9n0wJei7x2BNqw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@inversifyjs/common": "1.4.0",
+        "@inversifyjs/core": "1.3.5"
+      },
+      "peerDependencies": {
+        "reflect-metadata": "~0.2.2"
+      }
+    },
     "node_modules/minimatch": {
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
@@ -549,6 +621,13 @@
         "node": ">=10"
       }
     },
+    "node_modules/reflect-metadata": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
+      "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
+      "license": "Apache-2.0",
+      "peer": true
+    },
     "node_modules/semver": {
       "version": "7.7.3",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
@@ -560,6 +639,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/sprotty-protocol": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/sprotty-protocol/-/sprotty-protocol-1.4.0.tgz",
+      "integrity": "sha512-+AAskW3Mzcq5UhMnummp4wwJ1dYdgT7/utmWoHtjfrK7JTJq9G/VWWlHnTnQGzHHyma03Loy2AozToXoArQuAQ==",
+      "license": "(EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0)"
     },
     "node_modules/typescript": {
       "version": "5.9.3",
@@ -581,6 +666,19 @@
       "integrity": "sha512-QQiYxHuyZ9gQUIrmPo3IA+hUl4KYk8uSA7cHrcKd/l3p1OTpZcM0Tbp9x7FAtXdAYhlasd60ncPpgu6ihG6TOA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
     },
     "node_modules/vscode-jsonrpc": {
       "version": "8.2.0",
@@ -620,6 +718,42 @@
       "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
       "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
       "license": "MIT"
+    },
+    "node_modules/vscode-messenger": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/vscode-messenger/-/vscode-messenger-0.4.5.tgz",
+      "integrity": "sha512-a6e54dpPRi/ITmVex49LGU6YXlqcuxGPlDPauvZig20G1D1/QD2E8GfhtvlTj3ml5aU/QV3LHghyepq3riy7sw==",
+      "license": "MIT",
+      "dependencies": {
+        "vscode-messenger-common": "^0.4.5"
+      }
+    },
+    "node_modules/vscode-messenger-common": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/vscode-messenger-common/-/vscode-messenger-common-0.4.5.tgz",
+      "integrity": "sha512-opA+BEYTWdy1fFC3oOw30b0zc/KEuMtw+1pOiH5fEp+BGeA5xff7omSQTZeZJSDJszM471Vi+YY/ipRdRglAlQ==",
+      "license": "MIT"
+    },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     }
   }
 }

--- a/client/package.json
+++ b/client/package.json
@@ -74,6 +74,10 @@
       {
         "command": "interlis.docx.export",
         "title": "INTERLIS: Export documentation as DOCX"
+      },
+      {
+        "command": "interlis.glsp.info",
+        "title": "INTERLIS: Show GLSP server info"
       }
     ],
     "configuration": {
@@ -132,6 +136,7 @@
     "typescript": "^5.9.2"
   },
   "dependencies": {
+    "@eclipse-glsp/vscode-integration": "^2.5.0",
     "vscode-languageclient": "^9.0.1"
   }
 }

--- a/client/src/glspSupport.ts
+++ b/client/src/glspSupport.ts
@@ -1,0 +1,31 @@
+import * as vscode from 'vscode';
+import { LanguageClient } from 'vscode-languageclient/node';
+
+export interface GlspConnectionInfo {
+    host: string;
+    port: number;
+    path: string;
+    running: boolean;
+}
+
+export class GlspSupport {
+    private cached: GlspConnectionInfo | undefined;
+
+    constructor(private readonly client: LanguageClient) {}
+
+    async refresh(): Promise<GlspConnectionInfo | undefined> {
+        try {
+            const info = await this.client.sendRequest<GlspConnectionInfo>('interlis/glspInfo', {});
+            this.cached = info;
+            return info;
+        } catch (err: unknown) {
+            const message = err instanceof Error ? err.message : String(err);
+            void vscode.window.showWarningMessage(`INTERLIS GLSP server info unavailable: ${message}`);
+            return undefined;
+        }
+    }
+
+    get info(): GlspConnectionInfo | undefined {
+        return this.cached;
+    }
+}

--- a/src/main/java/ch/so/agi/glsp/interlis/InterlisGModelFactory.java
+++ b/src/main/java/ch/so/agi/glsp/interlis/InterlisGModelFactory.java
@@ -1,0 +1,76 @@
+package ch.so.agi.glsp.interlis;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import org.eclipse.glsp.graph.GGraph;
+import org.eclipse.glsp.server.features.core.model.GModelFactory;
+import org.eclipse.glsp.server.model.GModelState;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.inject.Inject;
+
+import ch.interlis.ili2c.metamodel.TransferDescription;
+import ch.so.agi.lsp.interlis.ClientSettings;
+import ch.so.agi.lsp.interlis.Ili2cUtil;
+import ch.so.agi.lsp.interlis.InterlisLanguageServer;
+import ch.so.agi.lsp.interlis.InterlisTextDocumentService;
+import ch.so.agi.lsp.interlis.InterlisUmlDiagram;
+
+final class InterlisGModelFactory implements GModelFactory {
+    private static final Logger LOG = LoggerFactory.getLogger(InterlisGModelFactory.class);
+
+    private final GModelState modelState;
+    private final InterlisLanguageServer languageServer;
+
+    @Inject
+    InterlisGModelFactory(GModelState modelState, InterlisLanguageServer languageServer) {
+        this.modelState = Objects.requireNonNull(modelState, "modelState");
+        this.languageServer = Objects.requireNonNull(languageServer, "languageServer");
+    }
+
+    @Override
+    public void createGModel() {
+        String sourceUri = modelState.getProperty(InterlisGlspConstants.PROP_SOURCE_URI, String.class).orElse(null);
+        Map<String, String> options = modelState.getClientOptions();
+        if (options != null) {
+            String candidate = options.get(InterlisGlspConstants.OPTION_SOURCE_URI);
+            if (candidate != null && !candidate.isBlank()) {
+                sourceUri = candidate;
+                modelState.setProperty(InterlisGlspConstants.PROP_SOURCE_URI, candidate);
+            }
+        }
+
+        if (sourceUri == null || sourceUri.isBlank()) {
+            modelState.updateRoot(InterlisGlspModelBuilder.buildMessageGraph("Select an INTERLIS file to view the diagram."));
+            return;
+        }
+
+        String path = InterlisTextDocumentService.toFilesystemPathIfPossible(sourceUri);
+        if (path == null || path.isBlank()) {
+            LOG.warn("Cannot resolve path for URI {}", sourceUri);
+            modelState.updateRoot(InterlisGlspModelBuilder.buildMessageGraph("Unable to resolve model path."));
+            return;
+        }
+
+        ClientSettings settings = languageServer.getClientSettings();
+        Ili2cUtil.CompilationOutcome outcome = Ili2cUtil.compile(settings, path);
+        TransferDescription td = outcome != null ? outcome.getTransferDescription() : null;
+        if (td == null) {
+            LOG.warn("No transfer description returned for {}", path);
+            modelState.updateRoot(InterlisGlspModelBuilder.buildMessageGraph("INTERLIS compilation failed."));
+            return;
+        }
+
+        List<InterlisUmlDiagram.ClassEntry> classes = InterlisUmlDiagram.collectPrimaryClasses(td);
+        if (classes.isEmpty()) {
+            modelState.updateRoot(InterlisGlspModelBuilder.buildMessageGraph("No classes found in the INTERLIS model."));
+            return;
+        }
+
+        GGraph root = InterlisGlspModelBuilder.buildClassDiagram(classes);
+        modelState.updateRoot(root);
+    }
+}

--- a/src/main/java/ch/so/agi/glsp/interlis/InterlisGlspConstants.java
+++ b/src/main/java/ch/so/agi/glsp/interlis/InterlisGlspConstants.java
@@ -1,0 +1,17 @@
+package ch.so.agi.glsp.interlis;
+
+final class InterlisGlspConstants {
+    private InterlisGlspConstants() {
+    }
+
+    static final String DIAGRAM_TYPE = "interlis-class-diagram";
+    static final String GRAPH_TYPE = "interlis::graph";
+    static final String CLASS_NODE_TYPE = "interlis::class";
+    static final String CLASS_LABEL_TYPE = "interlis::classLabel";
+    static final String NAMESPACE_LABEL_TYPE = "interlis::namespaceLabel";
+
+    static final String OPTION_SOURCE_URI = "sourceUri";
+    static final String PROP_SOURCE_URI = "ch.so.agi.glsp.interlis.sourceUri";
+
+    static final String WEBSOCKET_PATH = "interlis";
+}

--- a/src/main/java/ch/so/agi/glsp/interlis/InterlisGlspDiagramConfiguration.java
+++ b/src/main/java/ch/so/agi/glsp/interlis/InterlisGlspDiagramConfiguration.java
@@ -1,0 +1,31 @@
+package ch.so.agi.glsp.interlis;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.emf.ecore.EClass;
+import org.eclipse.glsp.server.diagram.BaseDiagramConfiguration;
+import org.eclipse.glsp.server.types.EdgeTypeHint;
+import org.eclipse.glsp.server.types.ShapeTypeHint;
+
+final class InterlisGlspDiagramConfiguration extends BaseDiagramConfiguration {
+    InterlisGlspDiagramConfiguration() {
+        this.diagramType = InterlisGlspConstants.DIAGRAM_TYPE;
+    }
+
+    @Override
+    public Map<String, EClass> getTypeMappings() {
+        return Collections.emptyMap();
+    }
+
+    @Override
+    public List<ShapeTypeHint> getShapeTypeHints() {
+        return List.of(createDefaultShapeTypeHint(InterlisGlspConstants.CLASS_NODE_TYPE));
+    }
+
+    @Override
+    public List<EdgeTypeHint> getEdgeTypeHints() {
+        return List.of();
+    }
+}

--- a/src/main/java/ch/so/agi/glsp/interlis/InterlisGlspDiagramModule.java
+++ b/src/main/java/ch/so/agi/glsp/interlis/InterlisGlspDiagramModule.java
@@ -1,0 +1,40 @@
+package ch.so.agi.glsp.interlis;
+
+import org.eclipse.glsp.server.diagram.DiagramConfiguration;
+import org.eclipse.glsp.server.di.DiagramModule;
+import org.eclipse.glsp.server.features.core.model.GModelFactory;
+import org.eclipse.glsp.server.features.core.model.SourceModelStorage;
+
+final class InterlisGlspDiagramModule extends DiagramModule {
+    private final ch.so.agi.lsp.interlis.InterlisLanguageServer languageServer;
+
+    InterlisGlspDiagramModule(ch.so.agi.lsp.interlis.InterlisLanguageServer languageServer) {
+        this.languageServer = languageServer;
+    }
+
+    @Override
+    protected void configureAdditionals() {
+        super.configureAdditionals();
+        bind(ch.so.agi.lsp.interlis.InterlisLanguageServer.class).toInstance(languageServer);
+    }
+
+    @Override
+    protected Class<? extends DiagramConfiguration> bindDiagramConfiguration() {
+        return InterlisGlspDiagramConfiguration.class;
+    }
+
+    @Override
+    protected Class<? extends SourceModelStorage> bindSourceModelStorage() {
+        return InterlisSourceModelStorage.class;
+    }
+
+    @Override
+    protected Class<? extends GModelFactory> bindGModelFactory() {
+        return InterlisGModelFactory.class;
+    }
+
+    @Override
+    public String getDiagramType() {
+        return InterlisGlspConstants.DIAGRAM_TYPE;
+    }
+}

--- a/src/main/java/ch/so/agi/glsp/interlis/InterlisGlspModelBuilder.java
+++ b/src/main/java/ch/so/agi/glsp/interlis/InterlisGlspModelBuilder.java
@@ -1,0 +1,69 @@
+package ch.so.agi.glsp.interlis;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import org.eclipse.glsp.graph.GGraph;
+import org.eclipse.glsp.graph.builder.impl.GGraphBuilder;
+import org.eclipse.glsp.graph.builder.impl.GLabelBuilder;
+import org.eclipse.glsp.graph.builder.impl.GNodeBuilder;
+
+import ch.so.agi.lsp.interlis.InterlisUmlDiagram;
+
+final class InterlisGlspModelBuilder {
+    private InterlisGlspModelBuilder() {
+    }
+
+    static GGraph buildClassDiagram(List<InterlisUmlDiagram.ClassEntry> classes) {
+        Objects.requireNonNull(classes, "classes");
+
+        GGraphBuilder graph = new GGraphBuilder(InterlisGlspConstants.GRAPH_TYPE)
+                .id("interlis-class-diagram")
+                .layoutOptions(Map.of("direction", "RIGHT"));
+
+        for (InterlisUmlDiagram.ClassEntry entry : classes) {
+            if (entry == null || entry.fqn() == null) {
+                continue;
+            }
+            GNodeBuilder classNode = new GNodeBuilder(InterlisGlspConstants.CLASS_NODE_TYPE)
+                    .id(entry.fqn())
+                    .layout("vbox");
+
+            classNode.add(new GLabelBuilder(InterlisGlspConstants.CLASS_LABEL_TYPE)
+                    .id(entry.fqn() + "#name")
+                    .text(entry.displayName() != null ? entry.displayName() : fallbackName(entry.fqn()))
+                    .build());
+
+            if (entry.namespace() != null && !entry.namespace().isBlank()) {
+                classNode.add(new GLabelBuilder(InterlisGlspConstants.NAMESPACE_LABEL_TYPE)
+                        .id(entry.fqn() + "#namespace")
+                        .text(entry.namespace())
+                        .build());
+            }
+
+            graph.add(classNode.build());
+        }
+
+        return graph.build();
+    }
+
+    static GGraph buildMessageGraph(String message) {
+        String text = (message == null || message.isBlank()) ? "No INTERLIS model available" : message;
+        return new GGraphBuilder(InterlisGlspConstants.GRAPH_TYPE)
+                .id("interlis-class-diagram-empty")
+                .add(new GLabelBuilder(InterlisGlspConstants.CLASS_LABEL_TYPE)
+                        .id("message")
+                        .text(text)
+                        .build())
+                .build();
+    }
+
+    private static String fallbackName(String fqn) {
+        if (fqn == null || fqn.isBlank()) {
+            return "Unnamed";
+        }
+        int idx = fqn.lastIndexOf('.');
+        return idx >= 0 && idx + 1 < fqn.length() ? fqn.substring(idx + 1) : fqn;
+    }
+}

--- a/src/main/java/ch/so/agi/glsp/interlis/InterlisGlspServer.java
+++ b/src/main/java/ch/so/agi/glsp/interlis/InterlisGlspServer.java
@@ -1,0 +1,87 @@
+package ch.so.agi.glsp.interlis;
+
+import java.util.Objects;
+
+import org.eclipse.glsp.server.di.DiagramModule;
+import org.eclipse.glsp.server.di.ServerModule;
+import org.eclipse.glsp.server.websocket.WebsocketServerLauncher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import ch.so.agi.lsp.interlis.InterlisLanguageServer;
+
+public final class InterlisGlspServer {
+    private static final Logger LOG = LoggerFactory.getLogger(InterlisGlspServer.class);
+
+    private final InterlisLanguageServer languageServer;
+    private final String host;
+    private final int port;
+    private final WebsocketServerLauncher launcher;
+
+    private volatile boolean started;
+
+    public InterlisGlspServer(InterlisLanguageServer languageServer) {
+        this.languageServer = Objects.requireNonNull(languageServer, "languageServer");
+        this.host = System.getProperty("interlis.glsp.host", "127.0.0.1");
+        int configuredPort = Integer.getInteger("interlis.glsp.port", 7057);
+        if (configuredPort <= 0 || configuredPort > 65535) {
+            LOG.warn("Configured interlis.glsp.port={} out of range, using default 7057", configuredPort);
+            configuredPort = 7057;
+        }
+        this.port = configuredPort;
+
+        DiagramModule diagramModule = new InterlisGlspDiagramModule(languageServer);
+        ServerModule serverModule = new InterlisGlspServerModule(languageServer);
+        serverModule.configureDiagramModule(diagramModule);
+        this.launcher = new WebsocketServerLauncher(serverModule, InterlisGlspConstants.WEBSOCKET_PATH);
+    }
+
+    public synchronized void start() {
+        if (started) {
+            return;
+        }
+        try {
+            launcher.start(host, port);
+            started = true;
+            LOG.info("Started INTERLIS GLSP server on {}:{}{}", host, port, pathWithSlash());
+        } catch (RuntimeException ex) {
+            LOG.error("Failed to start INTERLIS GLSP server", ex);
+            throw ex;
+        }
+    }
+
+    public synchronized void stop() {
+        if (!started) {
+            return;
+        }
+        try {
+            launcher.shutdown();
+        } finally {
+            started = false;
+        }
+    }
+
+    public String getHost() {
+        return host;
+    }
+
+    public int getPort() {
+        return port;
+    }
+
+    public String getEndpointPath() {
+        return InterlisGlspConstants.WEBSOCKET_PATH;
+    }
+
+    public boolean isStarted() {
+        return started;
+    }
+
+    private String pathWithSlash() {
+        String path = InterlisGlspConstants.WEBSOCKET_PATH;
+        if (path == null || path.isEmpty()) {
+            return "";
+        }
+        return path.startsWith("/") ? path : "/" + path;
+    }
+}

--- a/src/main/java/ch/so/agi/glsp/interlis/InterlisGlspServerModule.java
+++ b/src/main/java/ch/so/agi/glsp/interlis/InterlisGlspServerModule.java
@@ -1,0 +1,19 @@
+package ch.so.agi.glsp.interlis;
+
+import org.eclipse.glsp.server.di.ServerModule;
+
+import ch.so.agi.lsp.interlis.InterlisLanguageServer;
+
+final class InterlisGlspServerModule extends ServerModule {
+    private final InterlisLanguageServer languageServer;
+
+    InterlisGlspServerModule(InterlisLanguageServer languageServer) {
+        this.languageServer = languageServer;
+    }
+
+    @Override
+    protected void configureAdditionals() {
+        super.configureAdditionals();
+        bind(InterlisLanguageServer.class).toInstance(languageServer);
+    }
+}

--- a/src/main/java/ch/so/agi/glsp/interlis/InterlisSourceModelStorage.java
+++ b/src/main/java/ch/so/agi/glsp/interlis/InterlisSourceModelStorage.java
@@ -1,0 +1,34 @@
+package ch.so.agi.glsp.interlis;
+
+import java.util.Map;
+import java.util.Objects;
+
+import org.eclipse.glsp.server.actions.SaveModelAction;
+import org.eclipse.glsp.server.features.core.model.RequestModelAction;
+import org.eclipse.glsp.server.features.core.model.SourceModelStorage;
+import org.eclipse.glsp.server.model.GModelState;
+
+import com.google.inject.Inject;
+
+final class InterlisSourceModelStorage implements SourceModelStorage {
+    private final GModelState modelState;
+
+    @Inject
+    InterlisSourceModelStorage(GModelState modelState) {
+        this.modelState = Objects.requireNonNull(modelState, "modelState");
+    }
+
+    @Override
+    public void loadSourceModel(RequestModelAction action) {
+        Map<String, String> options = action != null ? action.getOptions() : null;
+        String uri = options != null ? options.get(InterlisGlspConstants.OPTION_SOURCE_URI) : null;
+        if (uri != null && !uri.isBlank()) {
+            modelState.setProperty(InterlisGlspConstants.PROP_SOURCE_URI, uri);
+        }
+    }
+
+    @Override
+    public void saveSourceModel(SaveModelAction action) {
+        // read-only view for now
+    }
+}

--- a/src/main/java/ch/so/agi/lsp/interlis/InterlisLanguageServer.java
+++ b/src/main/java/ch/so/agi/lsp/interlis/InterlisLanguageServer.java
@@ -7,6 +7,8 @@ import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicReference;
 
+import ch.so.agi.glsp.interlis.InterlisGlspServer;
+
 /**
  * Main LSP entrypoint. Wires TextDocument/Workspace services and exposes capabilities.
  */
@@ -15,6 +17,7 @@ public class InterlisLanguageServer implements LanguageServer, LanguageClientAwa
     
     private final InterlisTextDocumentService textDocumentService;
     private final InterlisWorkspaceService workspaceService;
+    private final InterlisGlspServer glspServer;
     
     private final AtomicReference<ClientSettings> clientSettings = new AtomicReference<>(new ClientSettings());
 
@@ -23,10 +26,13 @@ public class InterlisLanguageServer implements LanguageServer, LanguageClientAwa
     public static final String CMD_GENERATE_PLANTUML = "interlis.uml.plant";
     public static final String REQ_EXPORT_DOCX = "interlis/exportDocx";
     public static final String REQ_EXPORT_HTML = "interlis/exportHtml";
+    public static final String REQ_GLSP_INFO = "interlis/glspInfo";
 
     public InterlisLanguageServer() {
         this.textDocumentService = new InterlisTextDocumentService(this);
         this.workspaceService = new InterlisWorkspaceService(this);
+        this.glspServer = new InterlisGlspServer(this);
+        this.glspServer.start();
     }
 
     // ---- LanguageServer ----
@@ -84,7 +90,7 @@ public class InterlisLanguageServer implements LanguageServer, LanguageClientAwa
 
     @Override
     public void exit() {
-        // no-op
+        glspServer.stop();
     }
 
     @Override
@@ -122,6 +128,14 @@ public class InterlisLanguageServer implements LanguageServer, LanguageClientAwa
         ClientSettings sanitized = s != null ? s : new ClientSettings();
         clientSettings.set(sanitized);
         textDocumentService.onClientSettingsUpdated(sanitized);
+    }
+
+    public InterlisGlspServer getGlspServer() {
+        return glspServer;
+    }
+
+    public InterlisTextDocumentService getInterlisTextDocumentService() {
+        return textDocumentService;
     }
     
     public void clearOutput() {

--- a/src/main/java/ch/so/agi/lsp/interlis/InterlisTextDocumentService.java
+++ b/src/main/java/ch/so/agi/lsp/interlis/InterlisTextDocumentService.java
@@ -114,6 +114,10 @@ public class InterlisTextDocumentService implements TextDocumentService {
         return CompletableFuture.completedFuture(edits);
     }
 
+    public String getTrackedDocumentText(String uri) {
+        return documents.getText(uri);
+    }
+
     @Override
     public CompletableFuture<Either<List<CompletionItem>, CompletionList>> completion(CompletionParams params) {
         return CompletableFutures.computeAsync(cancelChecker -> {
@@ -267,7 +271,7 @@ public class InterlisTextDocumentService implements TextDocumentService {
         }
     }
 
-    static String toFilesystemPathIfPossible(String uriOrPath) {
+    public static String toFilesystemPathIfPossible(String uriOrPath) {
         if (uriOrPath == null) return null;
         if (uriOrPath.startsWith("file:")) {
             try {
@@ -278,7 +282,7 @@ public class InterlisTextDocumentService implements TextDocumentService {
         return uriOrPath;
     }
 
-    static String readDocument(String uriOrPath) throws Exception {
+    public static String readDocument(String uriOrPath) throws Exception {
         if (uriOrPath == null) {
             return "";
         }

--- a/src/main/java/ch/so/agi/lsp/interlis/InterlisWorkspaceService.java
+++ b/src/main/java/ch/so/agi/lsp/interlis/InterlisWorkspaceService.java
@@ -23,6 +23,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
+import ch.so.agi.glsp.interlis.InterlisGlspServer;
+
 public class InterlisWorkspaceService implements WorkspaceService {
     private static final Logger LOG = LoggerFactory.getLogger(InterlisWorkspaceService.class);
     
@@ -108,6 +110,16 @@ public class InterlisWorkspaceService implements WorkspaceService {
 
         LOG.info("html export called with: {}", normalized);
         return handlers.exportHtml(normalized, params.getTitle());
+    }
+
+    @JsonRequest(InterlisLanguageServer.REQ_GLSP_INFO)
+    public CompletableFuture<GlspInfo> glspInfo() {
+        InterlisGlspServer glsp = server.getGlspServer();
+        if (glsp == null) {
+            return CompletableFuture.completedFuture(new GlspInfo("", 0, "", false));
+        }
+        return CompletableFuture.completedFuture(
+                new GlspInfo(glsp.getHost(), glsp.getPort(), glsp.getEndpointPath(), glsp.isStarted()));
     }
 
     private DocumentExportParams coerceExportParams(Object rawParams) {
@@ -392,6 +404,36 @@ public class InterlisWorkspaceService implements WorkspaceService {
             }
         }
         return null;
+    }
+
+    public static final class GlspInfo {
+        private final String host;
+        private final int port;
+        private final String path;
+        private final boolean running;
+
+        public GlspInfo(String host, int port, String path, boolean running) {
+            this.host = host != null ? host : "";
+            this.port = port;
+            this.path = path != null ? path : "";
+            this.running = running;
+        }
+
+        public String getHost() {
+            return host;
+        }
+
+        public int getPort() {
+            return port;
+        }
+
+        public String getPath() {
+            return path;
+        }
+
+        public boolean isRunning() {
+            return running;
+        }
     }
 
     public static class DocumentExportParams {


### PR DESCRIPTION
## Summary
- add Eclipse GLSP server dependencies and bootstrap classes for an INTERLIS class-diagram websocket endpoint
- expose utilities in the language server to share live document data and return GLSP connection info
- extend the VS Code extension with a helper that queries the GLSP endpoint and registers a status command

## Testing
- ./gradlew classes
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f5f578acc4832898c51e7a8f8ea135