### PR TITLE
Fix GLSP webview ContainerConfiguration import

### DIFF
--- a/client/src/glsp/interlisGlspWebview.ts
+++ b/client/src/glsp/interlisGlspWebview.ts
@@ -1,7 +1,7 @@
 import 'reflect-metadata';
-import { Container, ContainerConfiguration } from 'inversify';
+import { Container } from 'inversify';
 import { GLSPStarter, VSCODE_DEFAULT_MODULE_CONFIG } from '@eclipse-glsp/vscode-integration-webview';
-import { initializeDiagramContainer } from '@eclipse-glsp/client';
+import { initializeDiagramContainer, type ContainerConfiguration } from '@eclipse-glsp/client';
 
 class InterlisGlspWebviewStarter extends GLSPStarter {
   protected createContainer(...containerConfiguration: ContainerConfiguration): Container {


### PR DESCRIPTION
## Summary
- import ContainerConfiguration from @eclipse-glsp/client so the webview bundle compiles

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f9ef46b2d483288e166b12b07f7d86