### PR TITLE
Ensure client builds run TypeScript type checks

### DIFF
--- a/client/.vscode/tasks.json
+++ b/client/.vscode/tasks.json
@@ -1,0 +1,22 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "npm: build",
+      "type": "npm",
+      "script": "build",
+      "group": "build",
+      "problemMatcher": ["$tsc"],
+      "detail": "Type-check and bundle the extension and GLSP webview using esbuild."
+    },
+    {
+      "label": "npm: watch",
+      "type": "npm",
+      "script": "watch",
+      "isBackground": true,
+      "group": "build",
+      "problemMatcher": ["$tsc-watch"],
+      "detail": "Continuously type-check and rebuild the extension and GLSP webview bundles."
+    }
+  ]
+}

--- a/client/package.json
+++ b/client/package.json
@@ -137,8 +137,9 @@
   },
   "main": "./dist/extension.js",
   "scripts": {
-    "build": "esbuild src/extension.ts --bundle --platform=node --external:vscode --external:@eclipse-glsp/* --external:@vscode/codicons/* --loader:.css=text --loader:.ttf=file --loader:.svg=dataurl --outfile=dist/extension.js && esbuild src/glsp/interlisGlspWebview.ts --bundle --format=iife --platform=browser --external:@vscode/codicons/dist/codicon.css --outfile=dist/interlis-glsp-webview.js",
-    "watch": "esbuild src/extension.ts --bundle --platform=node --external:vscode --external:@eclipse-glsp/* --external:@vscode/codicons/* --loader:.css=text --loader:.ttf=file --loader:.svg=dataurl --outfile=dist/extension.js --watch"
+    "build": "node ./scripts/build.mjs",
+    "watch": "node ./scripts/build.mjs --watch",
+    "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
     "@types/node": "^24.5.2",

--- a/client/scripts/build.mjs
+++ b/client/scripts/build.mjs
@@ -1,0 +1,137 @@
+import { build, context } from 'esbuild';
+import path from 'node:path';
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const projectRoot = path.resolve(__dirname, '..');
+const tscExecutable = path.join(
+  projectRoot,
+  'node_modules',
+  '.bin',
+  process.platform === 'win32' ? 'tsc.cmd' : 'tsc'
+);
+const tscBaseArgs = ['--project', 'tsconfig.json', '--pretty', 'false'];
+
+function runCommand(command, args, { cwd = projectRoot } = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, { cwd, stdio: 'inherit' });
+
+    child.once('error', error => reject(error));
+    child.once('exit', code => {
+      if (code === 0) {
+        resolve();
+      } else {
+        reject(new Error(`${path.basename(command)} exited with code ${code ?? 'null'}`));
+      }
+    });
+  });
+}
+
+async function runTypeCheckOnce() {
+  await runCommand(tscExecutable, [...tscBaseArgs, '--noEmit']);
+}
+
+function startTypeCheckWatch() {
+  const child = spawn(tscExecutable, [...tscBaseArgs, '--noEmit', '--watch'], {
+    cwd: projectRoot,
+    stdio: 'inherit'
+  });
+
+  let shuttingDown = false;
+
+  child.on('error', error => {
+    console.error(error);
+    process.exit(1);
+  });
+
+  child.on('exit', code => {
+    if (shuttingDown) {
+      return;
+    }
+
+    if (code && code !== 0) {
+      process.exit(code);
+    }
+  });
+
+  return {
+    async dispose() {
+      if (shuttingDown) {
+        return;
+      }
+
+      shuttingDown = true;
+
+      await new Promise(resolve => {
+        const handleExit = () => resolve();
+
+        child.once('exit', handleExit);
+
+        if (!child.kill('SIGINT')) {
+          resolve();
+        }
+      });
+    }
+  };
+}
+
+const extensionOptions = {
+  entryPoints: ['src/extension.ts'],
+  bundle: true,
+  platform: 'node',
+  external: ['vscode', '@eclipse-glsp/*', '@vscode/codicons/*'],
+  loader: {
+    '.css': 'text',
+    '.ttf': 'file',
+    '.svg': 'dataurl'
+  },
+  outfile: 'dist/extension.js'
+};
+
+const glspOptions = {
+  entryPoints: ['src/glsp/interlisGlspWebview.ts'],
+  bundle: true,
+  platform: 'browser',
+  format: 'iife',
+  external: ['@vscode/codicons/dist/codicon.css'],
+  outfile: 'dist/interlis-glsp-webview.js'
+};
+
+const watch = process.argv.includes('--watch');
+
+async function run() {
+  if (watch) {
+    const typeCheckWatcher = startTypeCheckWatch();
+    const [extensionCtx, glspCtx] = await Promise.all([
+      context(extensionOptions),
+      context(glspOptions)
+    ]);
+
+    await Promise.all([extensionCtx.watch(), glspCtx.watch()]);
+
+    console.log('Watching for changes...');
+
+    const dispose = async () => {
+      await Promise.all([
+        extensionCtx.dispose(),
+        glspCtx.dispose(),
+        typeCheckWatcher.dispose()
+      ]);
+      process.exit(0);
+    };
+
+    process.on('SIGINT', dispose);
+    process.on('SIGTERM', dispose);
+
+    await new Promise(() => {});
+  } else {
+    await runTypeCheckOnce();
+    await Promise.all([build(extensionOptions), build(glspOptions)]);
+  }
+}
+
+run().catch(error => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add a TypeScript type-checking step to the reusable build script so every source file is validated before bundling
- keep the watch task running tsc --watch alongside esbuild and surface diagnostics via VS Code problem matchers
- expose a dedicated npm run typecheck helper for manual verification

## Testing
- npm run build
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68f9f6d44cd08328a5f93b10c7542564